### PR TITLE
Fix configuration search logic

### DIFF
--- a/cowrie.tac
+++ b/cowrie.tac
@@ -16,7 +16,7 @@ if os.name == 'posix' and os.getuid() == 0:
     print 'ERROR: You must not run cowrie as root!'
     sys.exit(1)
 
-if not os.path.exists('cowrie.cfg'):
+if not (os.path.exists('cowrie.cfg') or os.path.exists('data/cowrie.cfg') or os.path.exists('/etc/cowrie.cfg') or os.path.exists('/etc/cowrie/cowrie.cfg')):
     print 'ERROR: cowrie.cfg is missing!'
     sys.exit(1)
 

--- a/cowrie/core/config.py
+++ b/cowrie/core/config.py
@@ -6,7 +6,7 @@ import ConfigParser
 
 def config():
     cfg = ConfigParser.ConfigParser()
-    for f in ('cowrie.cfg', '/etc/cowrie/cowrie.cfg', '/etc/cowrie.cfg'):
+    for f in ('cowrie.cfg', 'data/cowrie.cfg', '/etc/cowrie/cowrie.cfg', '/etc/cowrie.cfg'):
         if os.path.exists(f):
             cfg.read(f)
             return cfg


### PR DESCRIPTION
So far, cowrie searched config file in current directory although config parser can find it in /etc/ as well. 
