### PR TITLE
Support for shell escape sequences in echo command

### DIFF
--- a/cowrie/commands/base.py
+++ b/cowrie/commands/base.py
@@ -3,6 +3,8 @@
 
 import time
 import datetime
+import functools
+import getopt
 
 from twisted.internet import reactor
 from twisted.python import log
@@ -100,7 +102,20 @@ commands['/usr/bin/who'] = command_who
 
 class command_echo(HoneyPotCommand):
     def call(self):
-        self.writeln(' '.join(self.args))
+        write_fn = self.writeln
+        escape_fn = lambda s: s
+        optlist, args = getopt.getopt(self.args, "eEn")
+
+        for opt in optlist:
+            if opt[0] == '-e':
+                escape_fn = functools.partial(str.decode, encoding="string_escape")
+            elif opt[0] == '-E':
+                escape_fn = lambda s: s
+            elif opt[0] == '-n':
+                write_fn = self.write
+
+        write_fn(escape_fn(' '.join(args)))
+
 commands['/bin/echo'] = command_echo
 
 # for testing purposes


### PR DESCRIPTION
Some botnets use echo command to differentiate real shell (busybox, bash) from fake shells. For example using `echo -e \\x77\\x65\\x6c\\x63\\x30\\x6d\\x65`.

This patch helps mimic echo command of real shell that supports escaping.
