### PR TITLE
Add SSL Support to wget and curl

### DIFF
--- a/cowrie/commands/curl.py
+++ b/cowrie/commands/curl.py
@@ -12,8 +12,10 @@ import getopt
 import hashlib
 
 from twisted.web import client
-from twisted.internet import reactor
+from twisted.internet import reactor, ssl
 from twisted.python import log
+
+from OpenSSL import SSL
 
 from cowrie.core.honeypot import HoneyPotCommand
 from cowrie.core.fs import *
@@ -112,11 +114,7 @@ class command_curl(HoneyPotCommand):
             host = parsed.hostname
             port = parsed.port or (443 if scheme == 'https' else 80)
             path = parsed.path or '/'
-            if scheme == 'https':
-                self.writeln('Sorry, SSL not supported in this release')
-                self.exit()
-                return None
-            elif scheme != 'http':
+            if scheme != 'http' and scheme != 'https':
                 raise exceptions.NotImplementedError
         except:
             self.writeln('%s: Unsupported scheme.' % (url,))
@@ -132,8 +130,15 @@ class command_curl(HoneyPotCommand):
         out_addr = None
         if self.honeypot.env.cfg.has_option('honeypot', 'out_addr'):
             out_addr = (self.honeypot.env.cfg.get('honeypot', 'out_addr'), 0)
-        self.connection = reactor.connectTCP(
-            host, port, factory, bindAddress=out_addr)
+
+        if scheme == 'https':
+            contextFactory = ssl.ClientContextFactory()
+            contextFactory.method = SSL.SSLv23_METHOD
+            reactor.connectSSL(host, port, factory, contextFactory)
+        else: #can only be http
+            self.connection = reactor.connectTCP(
+                host, port, factory, bindAddress=out_addr)
+
         return factory.deferred
 
     def handle_CTRL_C(self):


### PR DESCRIPTION
Roughly related to #6 

This pull request adds SSL support to wget and curl commands, and rejects all protocols except http and https. This is needed because lack of SSL support can be used to fingerprint a cowrie honeypot. Most production curl and wget releases support https. I have not observed any attacker using https but this is an enhancement which reduces the chances of cowrie being fingerprinted.

Requires python-openssl to be installed, which was already installed on my (clean) Debian 8 platform.
