### PR TITLE
Parse shell commands more carefully

### DIFF
--- a/cowrie/core/honeypot.py
+++ b/cowrie/core/honeypot.py
@@ -59,11 +59,28 @@ class HoneyPotShell(object):
             'PATH':     '/bin:/usr/bin:/sbin:/usr/sbin',
             }
 
+    def parseCommands(self, line):
+        separators = [';', '&&', '||']
+        tokens = shlex.split(line, True) # ignore comments
+        commands = []
+        command = ''
+        for t in tokens:
+            if t not in separators:
+                if len(command):
+                    command = command + ' ' + t
+                else:
+                    command = t
+            else:
+                commands.append(command)
+                command = ''
+        commands.append(command)
+        return commands
+
     def lineReceived(self, line):
         log.msg('CMD: %s' % (line,))
         line = line[:500]
         comment = re.compile('^\s*#')
-        for i in [x.strip() for x in re.split(';|&&|\n', line.strip())[:10]]:
+        for i in [x.strip() for x in self.parseCommands(line)]:
             if not len(i):
                 continue
             if comment.match(i):


### PR DESCRIPTION
Commands like `echo "foo; bar"` and `ls foo || ls bar` currently get garbled and make it really obvious the shell.. isn't a shell. or is a very dumb shell :)

For comparison, before:

```
root@svr04:~# ls foo || ls bar
ls: cannot access /root/foo: No such file or directory
ls: cannot access /root/|: No such file or directory
ls: cannot access /root/|: No such file or directory
ls: cannot access /root/ls: No such file or directory
ls: cannot access /root/bar: No such file or directory
```

after:

```
root@svr04:~# ls foo || ls bar                                                                                                                                                                     
ls: cannot access /root/foo: No such file or directory
ls: cannot access /root/bar: No such file or directory
```

My python is pretty abysmal, so critique is welcome!
