### PR TITLE
Update Cowrie to support integration with MHN

### DIFF
--- a/cowrie.cfg.dist
+++ b/cowrie.cfg.dist
@@ -26,6 +26,13 @@
 # (default: 2222)
 #listen_port = 2222
 
+# Source Port to report in logs (useful if you use iptables to forward ports to cowrie)
+#reported_ssh_port = 22
+
+# Enable to log the public IP of the honeypot (useful if listening on 127.0.0.1)
+# IP address is obtained by querying http://myip.threatstream.com
+#report_public_ip = true
+
 # Hostname for the honeypot. Displayed by the shell prompt of the virtual
 # environment.
 #

--- a/cowrie/dblog/hpfeeds.py
+++ b/cowrie/dblog/hpfeeds.py
@@ -103,6 +103,9 @@ class hpclient(object):
 			self.handle_established()
 
 	def send(self, data):
+		if not self.s:
+			self.connect()
+
 		if not self.s: return
 		self.s.send(data)
 


### PR DESCRIPTION
This ports all of the features added to ThreatStream's version of Kippo to Cowrie.  This will enable Cowrie to be used as a MHN honeypot in place of Kippo with no loss in functionality.

Both the `reported_ssh_port` and `report_public_ip` options are disabled by default to preserve the current behavior of Cowrie.
