### PR TITLE
Wget and defers

### DIFF
--- a/cowrie/commands/curl.py
+++ b/cowrie/commands/curl.py
@@ -176,7 +176,7 @@ class command_curl(HoneyPotCommand):
         # update the honeyfs to point to downloaded file
         f = self.fs.getfile(outfile)
         f[A_REALFILE] = hash_path
-	del self.protocol.deferred_pending_command
+        del self.protocol.deferred_pending_command
         self.exit()
 
     def error(self, error, url):
@@ -186,7 +186,7 @@ class command_curl(HoneyPotCommand):
         # Real curl also adds this:
         #self.writeln('%s ERROR 404: Not Found.' % \
         #    time.strftime('%Y-%m-%d %T'))
-	del self.protocol.deferred_pending_command
+        del self.protocol.deferred_pending_command
         self.exit()
 commands['/usr/bin/curl'] = command_curl
 

--- a/cowrie/commands/curl.py
+++ b/cowrie/commands/curl.py
@@ -106,6 +106,7 @@ class command_curl(HoneyPotCommand):
         if self.deferred:
             self.deferred.addCallback(self.success, outfile)
             self.deferred.addErrback(self.error, url)
+            self.protocol.deferred_pending_command = True
 
     def download(self, url, fakeoutfile, outputfile, *args, **kwargs):
         try:
@@ -175,6 +176,7 @@ class command_curl(HoneyPotCommand):
         # update the honeyfs to point to downloaded file
         f = self.fs.getfile(outfile)
         f[A_REALFILE] = hash_path
+	del self.protocol.deferred_pending_command
         self.exit()
 
     def error(self, error, url):
@@ -184,6 +186,7 @@ class command_curl(HoneyPotCommand):
         # Real curl also adds this:
         #self.writeln('%s ERROR 404: Not Found.' % \
         #    time.strftime('%Y-%m-%d %T'))
+	del self.protocol.deferred_pending_command
         self.exit()
 commands['/usr/bin/curl'] = command_curl
 

--- a/cowrie/commands/wget.py
+++ b/cowrie/commands/wget.py
@@ -109,6 +109,7 @@ class command_wget(HoneyPotCommand):
         if self.deferred:
             self.deferred.addCallback(self.success, outfile)
             self.deferred.addErrback(self.error, url)
+            self.protocol.deferred_pending_command = True
 
     def download(self, url, fakeoutfile, outputfile, *args, **kwargs):
         try:
@@ -179,6 +180,7 @@ class command_wget(HoneyPotCommand):
         # update the honeyfs to point to downloaded file
         f = self.fs.getfile(outfile)
         f[A_REALFILE] = hash_path
+	del self.protocol.deferred_pending_command
         self.exit()
 
     def error(self, error, url):
@@ -188,6 +190,7 @@ class command_wget(HoneyPotCommand):
         # Real wget also adds this:
         #self.writeln('%s ERROR 404: Not Found.' % \
         #    time.strftime('%Y-%m-%d %T'))
+	del self.protocol.deferred_pending_command
         self.exit()
 commands['/usr/bin/wget'] = command_wget
 

--- a/cowrie/commands/wget.py
+++ b/cowrie/commands/wget.py
@@ -180,7 +180,7 @@ class command_wget(HoneyPotCommand):
         # update the honeyfs to point to downloaded file
         f = self.fs.getfile(outfile)
         f[A_REALFILE] = hash_path
-	del self.protocol.deferred_pending_command
+        del self.protocol.deferred_pending_command
         self.exit()
 
     def error(self, error, url):
@@ -190,7 +190,7 @@ class command_wget(HoneyPotCommand):
         # Real wget also adds this:
         #self.writeln('%s ERROR 404: Not Found.' % \
         #    time.strftime('%Y-%m-%d %T'))
-	del self.protocol.deferred_pending_command
+        del self.protocol.deferred_pending_command
         self.exit()
 commands['/usr/bin/wget'] = command_wget
 

--- a/cowrie/core/honeypot.py
+++ b/cowrie/core/honeypot.py
@@ -7,6 +7,7 @@ import re
 import copy
 
 from twisted.python import log
+from twisted.internet import reactor
 
 from . import fs
 
@@ -39,6 +40,8 @@ class HoneyPotCommand(object):
 
     def lineReceived(self, line):
         log.msg('INPUT: %s' % (line,))
+	if isinstance(self.protocol.cmdstack[0], HoneyPotShell):
+		self.protocol.cmdstack[0].lineReceived(line)
 
     def resume(self):
         pass
@@ -82,6 +85,10 @@ class HoneyPotShell(object):
                 self.showPrompt()
             else:
                 self.protocol.terminal.transport.session.loseConnection()
+
+        if ( (self.protocol) and (hasattr(self.protocol, 'deferred_pending_command')) ):
+            reactor.callLater(1, self.runCommand)
+	    return
 
         if not len(self.cmdpending):
             if self.interactive:

--- a/cowrie/core/honeypot.py
+++ b/cowrie/core/honeypot.py
@@ -40,8 +40,8 @@ class HoneyPotCommand(object):
 
     def lineReceived(self, line):
         log.msg('INPUT: %s' % (line,))
-	if isinstance(self.protocol.cmdstack[0], HoneyPotShell):
-		self.protocol.cmdstack[0].lineReceived(line)
+        if isinstance(self.protocol.cmdstack[0], HoneyPotShell):
+            self.protocol.cmdstack[0].lineReceived(line)
 
     def resume(self):
         pass
@@ -88,7 +88,7 @@ class HoneyPotShell(object):
 
         if ( (self.protocol) and (hasattr(self.protocol, 'deferred_pending_command')) ):
             reactor.callLater(1, self.runCommand)
-	    return
+            return
 
         if not len(self.cmdpending):
             if self.interactive:

--- a/cowrie/core/ssh.py
+++ b/cowrie/core/ssh.py
@@ -397,14 +397,14 @@ class HoneyPotSSHSession(session.SSHSession):
 
     def eofReceived(self):
         log.msg('got eof')
-	if ( 
-		(self.avatar.protocol) and
-		(self.avatar.protocol.terminalProtocol) and
-		hasattr(self.avatar.protocol.terminalProtocol, 'deferred_pending_command')
-	   ):
-		reactor.callLater(1, self.eofReceived)
-	else:
-	        self.sendClose()
+        if ( 
+             (self.avatar.protocol) and
+             (self.avatar.protocol.terminalProtocol) and
+             (hasattr(self.avatar.protocol.terminalProtocol, 'deferred_pending_command')) 
+           ):
+            reactor.callLater(1, self.eofReceived)
+         else:
+            self.sendClose()
 
     # utility function to request to send close for this session
     def sendClose(self):

--- a/cowrie/core/ssh.py
+++ b/cowrie/core/ssh.py
@@ -16,7 +16,7 @@ import twisted.conch.ls
 from twisted.python import log, components
 from twisted.conch.openssh_compat import primes
 from twisted.conch.ssh.common import NS, getNS
-from twisted.internet import defer
+from twisted.internet import defer, reactor
 
 from . import credentials
 from . import auth
@@ -397,7 +397,14 @@ class HoneyPotSSHSession(session.SSHSession):
 
     def eofReceived(self):
         log.msg('got eof')
-        self.sendClose()
+	if ( 
+		(self.avatar.protocol) and
+		(self.avatar.protocol.terminalProtocol) and
+		hasattr(self.avatar.protocol.terminalProtocol, 'deferred_pending_command')
+	   ):
+		reactor.callLater(1, self.eofReceived)
+	else:
+	        self.sendClose()
 
     # utility function to request to send close for this session
     def sendClose(self):


### PR DESCRIPTION
regarding https://github.com/micheloosterhof/cowrie/issues/49

lately we have run into similar situation while auto-testing our deployed pots. The issue is: if command is run from non PTY terminal eg.
    sshpass -p X ssh user@pot 'wget url; something' </dev/null
the final eof is received and processed by ssh.py layer too soon destroying the session before wget could finish.

the situation described in issues/49 suffers similar problem. If command class itself does not override lineReceived() the input is just logged and dropped from cmdstack. if it would be at least "properly" inserted it would be executed prematurely within the pot.

so we suggest the creation of flag in shared object by commands which might be deferred in execution, and use that flag to resolved both issues.

I admit that I'm not really familiar with cowries/kippos internals so the solution is might be sub-optimal or even wrong, but please review it. thank you.
