### PR TITLE
elasticsearch output support - early release

### DIFF
--- a/cowrie.cfg.dist
+++ b/cowrie.cfg.dist
@@ -227,6 +227,14 @@ interact_port = 5123
 [output_jsonlog]
 logfile = log/cowrie.json
 
+# Supports logging to elasticsearch
+# This is a simple early release
+#
+#[output-elasticsearch]
+#host = localhost
+#port = 9200
+#index = cowrie
+#type = cowrie
 
 # Local Syslog output module
 #

--- a/cowrie/output/elasticsearch.py
+++ b/cowrie/output/elasticsearch.py
@@ -1,0 +1,34 @@
+# Simple elasticsearch logger
+
+import os
+import json
+
+import pyes 
+
+import cowrie.core.output
+
+
+class Output(cowrie.core.output.Output):
+
+
+    def __init__(self, cfg):
+        self.host = cfg.get('output_elasticsearch', 'host')
+        self.port = cfg.get('output_elasticsearch', 'port')
+        self.index = cfg.get('output_elasticsearch', 'index')
+        self.type = cfg.get('output_elasticsearch', 'type')
+        cowrie.core.output.Output.__init__(self, cfg)
+
+
+    def start(self):
+        self.es = pyes.ES('{0}:{1}'.format(self.host, self.port))
+
+    def stop(self):
+        pass
+
+    def write(self, logentry):
+        for i in logentry.keys():
+            # remove twisted 15 legacy keys
+            if i.startswith('log_'):
+                del logentry[i]
+
+        self.es.index(logentry, self.index, self.type)


### PR DESCRIPTION
This change adds basic Elasticsearch support. It uses the standard pyes library.

 I was unable to cause problems when blocking the honeypot from connecting to ES. If you find an issue, let me know. 

Some future that I'll work on adding are mappings, and an ability to change index based on date.
