### PR TITLE
Don't write stdin to ttylog when it's being stored to stdinlog

### DIFF
--- a/cowrie/core/protocol.py
+++ b/cowrie/core/protocol.py
@@ -318,13 +318,14 @@ class LoggingServerProtocol(insults.ServerProtocol):
 
     def dataReceived(self, data, noLog=False):
         transport = self.transport.session.conn.transport
-        if self.ttylog_open and not noLog:
-            ttylog.ttylog_write(transport.ttylog_file, len(data),
-                ttylog.TYPE_INPUT, time.time(), data)
-        if self.stdinlog_open and not noLog:
-            f = file(self.stdinlog_file, 'ab')
-            f.write(data)
-            f.close
+        if not noLog:
+            if self.stdinlog_open:
+                f = file(self.stdinlog_file, 'ab')
+                f.write(data)
+                f.close
+            elif self.ttylog_open:
+                ttylog.ttylog_write(transport.ttylog_file, len(data),
+                    ttylog.TYPE_INPUT, time.time(), data)
 
         insults.ServerProtocol.dataReceived(self, data)
 


### PR DESCRIPTION
This turns off logging of stdin to ttylog when it's being stored into stdinlog.

It's related to #59. Since "cat > file" is usually used to store a malware binary by the attackers, and since that data are already stored into stdinlog by cowrie, I think it's better to not store them also into ttylog. It complicates analysis of tty logs. Imagine you want to look what commands an attacker executed, so you run "./playlog.py -i -m 0 ttylogfile" and you get a megabyte of binary mess. Also, such ttylogs are quite large.
