### PR TITLE
Log non-interactively executed commands to ttylog

### DIFF
--- a/cowrie/core/protocol.py
+++ b/cowrie/core/protocol.py
@@ -203,6 +203,10 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
         """
         HoneyPotBaseProtocol.connectionMade(self)
         self.setTimeout(60)
+
+        # Write command to tty log
+        self.terminal.dataReceived(self.execcmd + '\n')
+
         self.terminal.stdinlog_open = True
 
         self.cmdstack = [honeypot.HoneyPotShell(self, interactive=False)]


### PR DESCRIPTION
Store "execcmd" to ttylog as if it would be sent via stdin. This allows to see the command executed (not only its output) when analyzing ttylogs.
However, I know it violates the principle that ttylog should capture only stdin and stdout of a session. I think it's still better to log the command, but feel free to reject the pull request if you don't agree.
