### PR TITLE
Add Session ID to names of ttylog and stdinlog files

### DIFF
--- a/cowrie/core/protocol.py
+++ b/cowrie/core/protocol.py
@@ -375,16 +375,22 @@ class LoggingServerProtocol(insults.ServerProtocol):
     def __init__(self, prot=None, *a, **kw):
         insults.ServerProtocol.__init__(self, prot, *a, **kw)
         self.cfg = a[0].cfg
+        if prot is HoneyPotExecProtocol:
+            self.type = 'e' # execcmd
+        else:
+            self.type = 'i' # interactive
 
 
     def connectionMade(self):
         """
         """
         transport = self.transport.session.conn.transport
+        channel_id = self.transport.session.id
 
-        transport.ttylog_file = '%s/tty/%s-%s.log' % \
+        transport.ttylog_file = '%s/tty/%s-%s-%s%s.log' % \
             (self.cfg.get('honeypot', 'log_path'),
-            time.strftime('%Y%m%d-%H%M%S'), transport.transportId)
+            time.strftime('%Y%m%d-%H%M%S'), transport.transportId, channel_id,
+            self.type)
 
         self.ttylog_file = transport.ttylog_file
         log.msg(eventid='KIPP0004', ttylog=transport.ttylog_file,
@@ -393,9 +399,9 @@ class LoggingServerProtocol(insults.ServerProtocol):
         ttylog.ttylog_open(transport.ttylog_file, time.time())
         self.ttylog_open = True
 
-        self.stdinlog_file = '%s/%s-%s-stdin.log' % \
+        self.stdinlog_file = '%s/%s-%s-%s-stdin.log' % \
             (self.cfg.get('honeypot', 'download_path'),
-            time.strftime('%Y%m%d-%H%M%S'), transport.transportId)
+            time.strftime('%Y%m%d-%H%M%S'), transport.transportId, channel_id)
         self.stdinlog_open = False
 
         insults.ServerProtocol.connectionMade(self)


### PR DESCRIPTION
I can see lots of connections using multiple sessions (usually used to run multiple commands, each in separate session of a single connection). Since names of ttylog files consists only of time and connection ID, not session ID, there may be a problem when two sessions are opened within a single second - logs of both sessions will be mixed in the same file.

The commit also adds 'i' or 'e' to the file name to distinguish 'interactive' and 'execcmd' types of sessions.

The format of log file names thus changes from
20151119-130454-860c2dd1.log
20151119-130455-860c2dd1.log
to
20151119-130454-860c2dd1-0e.log
20151119-130455-860c2dd1-1e.log

I hope it won't break some scripts people use to analyze the logs.
