### PR TITLE
Add wildcard support for file system creation

### DIFF
--- a/utils/createfs.py
+++ b/utils/createfs.py
@@ -1,7 +1,16 @@
 #!/usr/bin/env python
 
-import os, pickle, sys, locale, getopt
+###############################################################
+# This program creates a cowrie file system pickle file.
+#
+# This is meant to build a brand new filesystem.
+# To edit the file structure, please use './utils/fsctl.py'
+#
+##############################################################
+
+import os, pickle, sys, locale, getopt, fnmatch
 from stat import *
+
 
 A_NAME, A_TYPE, A_UID, A_GID, A_SIZE, A_MODE, \
     A_CTIME, A_CONTENTS, A_TARGET, A_REALFILE = range(0, 10)
@@ -9,9 +18,24 @@ T_LINK, T_DIR, T_FILE, T_BLK, T_CHR, T_SOCK, T_FIFO = range(0, 7)
 PROC = False
 VERBOSE = False
 
+blacklist_files = [
+            '/root/fs.pickle',
+            '/root/createfs.py',
+            '/root/.bash_history',
+            '*cowrie*',
+            '*kippo*',
+            ]
+
+
 def logit(ftxt):
     if VERBOSE:
         sys.stderr.write(ftxt)
+
+def checkblacklist(ftxt):
+    for value in blacklist_files:
+        if fnmatch.fnmatch(ftxt, value):
+            return True
+    return False
 
 def recurse(localroot, root, tree, maxdepth = sys.maxint):
     if maxdepth == 0: return
@@ -26,12 +50,9 @@ def recurse(localroot, root, tree, maxdepth = sys.maxint):
 
     for name in os.listdir(localpath):
         fspath = os.path.join(root, name)
-        if fspath in (
-                '/root/fs.pickle',
-                '/root/createfs.py',
-                '/root/.bash_history',
-                ):
+        if checkblacklist(fspath):
             continue
+
 
         path = os.path.join(localpath, name)
 
@@ -124,4 +145,3 @@ if __name__ == '__main__':
         pickle.dump(tree, open(output, 'wb'))
     else:
         print pickle.dumps(tree)
-

--- a/utils/fsctl.py
+++ b/utils/fsctl.py
@@ -7,8 +7,8 @@
 # It is intended to mimic a basic bash shell and supports relative
 # file references.
 #
-# This isn't meant to build a brand new filesystem. Instead it
-# should be used to edit existing filesystems such as the default
+# This isn't meant to build a brand new file system. Instead it
+# should be used to edit existing file systems such as the default
 # /opt/cowrie/data/fs.pickle.
 #
 # Donovan Hubbard
@@ -97,7 +97,7 @@ class fseditCmd(cmd.Cmd):
 
         self.update_pwd("/")
 
-        self.intro = "\nKippo file system interactive editor\n" + \
+        self.intro = "\nKippo/Cowrie file system interactive editor\n" + \
             "Donovan Hubbard, Douglas Hubbard, March 2013\n" + \
             "Type 'help' for help\n"
 
@@ -117,7 +117,7 @@ class fseditCmd(cmd.Cmd):
 
     def do_EOF(self, args):
         '''The escape character ctrl+d exits the session'''
-        #exiting from the do_EOF method does not create a newline automaticaly
+        #exiting from the do_EOF method does not create a newline automatically
         #so we add it manually
         print
         return True
@@ -292,7 +292,7 @@ class fseditCmd(cmd.Cmd):
         else:
             size = args[1]
 
-        #set the last update timestamp to now
+        #set the last update time stamp to now
         ctime = time.time()
 
         cwd[A_CONTENTS].append(
@@ -303,7 +303,7 @@ class fseditCmd(cmd.Cmd):
         print "Added '%s'" % path
 
     def do_rm(self, arguments):
-        '''Remove an object from the filesystem.
+        '''Remove an object from the file system.
         Will not remove a directory unless the -r switch is invoked.\n
         Usage: rm [-r] <target>'''
 
@@ -474,7 +474,7 @@ class fseditCmd(cmd.Cmd):
         #Get the object for source
         srcl = getpath(self.fs, src)
 
-        #Get the ojbect for the source's parent
+        #Get the object for the source's parent
         srcparentl = getpath(self.fs, srcparent)
 
         #if the specified filepath is a directory, maintain the current name
@@ -553,13 +553,13 @@ class fseditCmd(cmd.Cmd):
         print "Type help <topic> to get more information."
 
     def help_about(self):
-        print "Kippo stores information about its file systems in a " + \
+        print "Kippo/Cowrie stores information about its file systems in a " + \
             "series of nested lists. Once the lists are made, they are " + \
             "stored in a pickle file on the hard drive. Every time cowrie " + \
             "gets a new client, it reads from the pickle file and loads " + \
-            "the fake filesystem into memory. By default this file " + \
+            "the fake file system into memory. By default this file " + \
             "is /opt/cowrie/data/fs.pickle. Originally the script " + \
-            "/opt/cowrie/createfs.py was used to copy the filesystem " + \
+            "/opt/cowrie/createfs.py was used to copy the file system " + \
             "of the existing computer. However, it quite difficult to " + \
             "edit the pickle file by hand.\n\nThis script strives to be " + \
             "a bash-like interface that allows users to modify " + \


### PR DESCRIPTION
- Will not index anything `*cowrie*` or `*kippo*` (e.g. kippo-graph)
