### PR TITLE
Create parent directory & multi folders with fsctl.py

### DIFF
--- a/utils/fsctl.py
+++ b/utils/fsctl.py
@@ -1,21 +1,22 @@
 #!/usr/bin/python
 
-###############################################################
+################################################################
 # This program creates a command line interpreter used to edit
 # cowrie file system pickle files.
 #
-# It is intended to mimic a basic bash shell and supports relative
-# file references.
+# It is intended to mimic a basic bash shell and supports
+# relative file references.
 #
-# This isn't meant to build a brand new file system. Instead it
-# should be used to edit existing file systems such as the default
-# /opt/cowrie/data/fs.pickle.
+# Do not use to build a complete file system. Use:
+# /opt/cowrie/utils/createfs.py
+# Instead it should be used to edit existing file systems
+# such as the default: /opt/cowrie/data/fs.pickle.
 #
 # Donovan Hubbard
 # Douglas Hubbard
 # March 2013
 #
-###############################################################
+################################################################
 
 import os, pickle, sys, locale, time, cmd
 from stat import *
@@ -241,13 +242,14 @@ class fseditCmd(cmd.Cmd):
     def do_mkdir(self, args):
         """Add a new directory in the target directory.
         Handles relative or absolute file paths. \n
-        Usage: mkdir <destination>"""
+        Usage: mkdir <destination>..."""
 
         arg_list=args.split()
-        if len(arg_list) != 1:
-            print "usage: mkdir <new directory>"
+        if len(arg_list) < 1:
+            print "usage: mkdir <new directory> <new directory>..."
         else:
-            self.mkfile(arg_list, T_DIR)
+            for arg in arg_list:
+                self.mkfile(arg.split(), T_DIR)
 
     def do_touch(self, args):
         """Add a new file in the target directory.
@@ -270,10 +272,9 @@ class fseditCmd(cmd.Cmd):
         fileName = pathList[len(pathList) - 1]
 
         if not exists(self.fs, parentdir):
-            print ('Parent directory %s doesn\'t exist! ' +
-                'Please create it first.') % \
+            print ('Parent directory %s doesn\'t exist!') % \
                 (parentdir,)
-            return
+            self.mkfile(parentdir.split(), T_DIR)
 
         if exists(self.fs, path):
             print 'Error: %s already exists!' % (path,)


### PR DESCRIPTION
- `fsctl.py` will now always create parent directory when using `mkdir` (aka just like `mkdir -p` in bash)
- Able to make multiple folders in a single command `mkdir /path/1 /path/2 /path/3` when using `fsctl.py`

Example: 

```
fs.pickle:/$ mkdir /3/3/4/5
Parent directory /3/3/4 doesn't exist!
Parent directory /3/3 doesn't exist!
Parent directory /3 doesn't exist!
Added '/3'
Added '/3/3'
Added '/3/3/4'
Added '/3/3/4/5'
fs.pickle:/$
```
