### PR TITLE
Don't fail on non-existing username in /etc/passwd

### DIFF
--- a/cowrie/core/ssh.py
+++ b/cowrie/core/ssh.py
@@ -106,10 +106,15 @@ class CowrieUser(avatar.ConchUser):
             {"session": HoneyPotSSHSession,
              "direct-tcpip": CowrieOpenConnectForwardingClient})
 
-        pwentry = pwd.Passwd(self.cfg).getpwnam(self.username)
-        self.uid = pwentry["pw_uid"]
-        self.gid = pwentry["pw_gid"]
-        self.home = pwentry["pw_dir"]
+        try:
+            pwentry = pwd.Passwd(self.cfg).getpwnam(self.username)
+            self.uid = pwentry["pw_uid"]
+            self.gid = pwentry["pw_gid"]
+            self.home = pwentry["pw_dir"]
+        except:
+            self.uid = 1001
+            self.gid = 1001
+            self.home = '/home'
 
         # Sftp support enabled only when option is explicitly set
         try:


### PR DESCRIPTION
The AuthRandom auth class accepts random usernames, which may not exist in /etc/passwd.
