### PR TITLE
gitignore twisted cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ __pycache__/
 env/
 env1/
 env2/
+twisted/plugins/dropin.cache


### PR DESCRIPTION
I keep getting:

```
root@honeypot1:/opt/cowrie# git status
On branch active
Untracked files:
  (use "git add <file>..." to include in what will be committed)

    twisted/plugins/dropin.cache

nothing added to commit but untracked files present (use "git add" to track)
root@honeypot1:/opt/cowrie#
```
