### PR TITLE
Add log size to MySQL database

### DIFF
--- a/cowrie/core/output.py
+++ b/cowrie/core/output.py
@@ -37,7 +37,7 @@ import copy
 import socket
 
 # COW0001 : create session
-# COW0002 : succesful login
+# COW0002 : successful login
 # COW0003 : failed login
 # COW0004 : TTY log opened
 # COW0005 : handle command
@@ -168,4 +168,3 @@ class Output(object):
         if ev['eventid'] == 'COW0011':
             del self.sessions[sessionno]
             del self.ips[sessionno]
-

--- a/cowrie/insults/insults.py
+++ b/cowrie/insults/insults.py
@@ -160,8 +160,10 @@ class LoggingServerProtocol(insults.ServerProtocol):
 
         if self.ttylog_open:
             size = self.ttylog_size[self.ttylog_file]
-            log.msg(eventid='COW0012', format='Closing TTY Log: %(ttylog)s',
-                ttylog=self.ttylog_file, size=size)
+            log.msg(eventid='COW0012',
+                    format='Closing TTY Log: %(ttylog)s',
+                    ttylog=self.ttylog_file,
+                    size=size)
             ttylog.ttylog_close(self.ttylog_file, time.time())
             self.ttylog_open = False
 

--- a/cowrie/insults/insults.py
+++ b/cowrie/insults/insults.py
@@ -59,11 +59,13 @@ class LoggingServerProtocol(insults.ServerProtocol):
             time.strftime('%Y%m%d-%H%M%S'), transportId, channelId)
         self.stdinlog_open = False
 
-        insults.ServerProtocol.connectionMade(self)
+        self.ttylog_size = {self.ttylog_file: 0}
 
+        insults.ServerProtocol.connectionMade(self)
 
     def write(self, bytes):
         """
+        Output sent back to user
         """
         for i in self.interactors:
             i.sessionWrite(bytes)
@@ -72,11 +74,14 @@ class LoggingServerProtocol(insults.ServerProtocol):
             ttylog.ttylog_write(self.ttylog_file, len(bytes),
                 ttylog.TYPE_OUTPUT, time.time(), bytes)
 
+            self.ttylog_size[self.ttylog_file] += len(bytes)
+
         insults.ServerProtocol.write(self, bytes)
 
 
     def dataReceived(self, data):
         """
+        Input received from user
         """
         self.bytesReceived += len(data)
         if self.bytesReceivedLimit and self.bytesReceived > self.bytesReceivedLimit:
@@ -154,8 +159,9 @@ class LoggingServerProtocol(insults.ServerProtocol):
                 self.stdinlog_open = False
 
         if self.ttylog_open:
+            size = self.ttylog_size[self.ttylog_file]
             log.msg(eventid='COW0012', format='Closing TTY Log: %(ttylog)s',
-                ttylog=self.ttylog_file)
+                ttylog=self.ttylog_file, size=size)
             ttylog.ttylog_close(self.ttylog_file, time.time())
             self.ttylog_open = False
 

--- a/cowrie/output/mysql.py
+++ b/cowrie/output/mysql.py
@@ -187,7 +187,7 @@ class Output(cowrie.core.output.Output):
 
         elif entry["eventid"] == 'COW0012':
             self.simpleQuery(
-                'INSERT INTO `ttylog` (`session`, `ttylog`) VALUES (%s, %s)',
-                (entry["session"], entry["ttylog"]))
+                'INSERT INTO `ttylog` (`session`, `ttylog`, `size`) VALUES (%s, %s, %s)',
+                (entry["session"], entry["ttylog"], entry["size"]))
 
 # vim: set sw=4 et:

--- a/cowrie/output/mysql.py
+++ b/cowrie/output/mysql.py
@@ -190,4 +190,8 @@ class Output(cowrie.core.output.Output):
                 'INSERT INTO `ttylog` (`session`, `ttylog`, `size`) VALUES (%s, %s, %s)',
                 (entry["session"], entry["ttylog"], entry["size"]))
 
+        elif entry["eventid"] == 'COW0016':
+            self.simpleQuery(
+                'INSERT INTO `keyfingerprints` (`session`, `username`, `fingerprint`) VALUES (%s, %s, %s)',
+                (entry["session"], entry["username"], entry["fingerprint"]))
 # vim: set sw=4 et:

--- a/doc/sql/mysql.sql
+++ b/doc/sql/mysql.sql
@@ -46,7 +46,8 @@ CREATE TABLE `sessions` (
 CREATE TABLE `ttylog` (
   `id` int(11) NOT NULL auto_increment,
   `session` char(32) NOT NULL,
-  `ttylog` mediumblob NOT NULL,
+  `ttylog` varchar(100) NOT NULL,
+  `size` int(11) NOT NULL,
   PRIMARY KEY  (`id`)
 ) ;
 

--- a/doc/sql/mysql.sql
+++ b/doc/sql/mysql.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `auth` (
+CREATE TABLE IF NOT EXISTS `auth` (
   `id` int(11) NOT NULL auto_increment,
   `session` char(32) NOT NULL,
   `success` tinyint(1) NOT NULL,
@@ -8,13 +8,13 @@ CREATE TABLE `auth` (
   PRIMARY KEY  (`id`)
 ) ;
 
-CREATE TABLE `clients` (
+CREATE TABLE IF NOT EXISTS `clients` (
   `id` int(4) NOT NULL auto_increment,
   `version` varchar(50) NOT NULL,
   PRIMARY KEY  (`id`)
 ) ;
 
-CREATE TABLE `input` (
+CREATE TABLE IF NOT EXISTS `input` (
   `id` int(11) NOT NULL auto_increment,
   `session` char(32) NOT NULL,
   `timestamp` datetime NOT NULL,
@@ -25,13 +25,13 @@ CREATE TABLE `input` (
   KEY `session` (`session`,`timestamp`,`realm`)
 ) ;
 
-CREATE TABLE `sensors` (
+CREATE TABLE IF NOT EXISTS `sensors` (
   `id` int(11) NOT NULL auto_increment,
   `ip` varchar(15) NOT NULL,
   PRIMARY KEY  (`id`)
 ) ;
 
-CREATE TABLE `sessions` (
+CREATE TABLE IF NOT EXISTS `sessions` (
   `id` char(32) NOT NULL,
   `starttime` datetime NOT NULL,
   `endtime` datetime default NULL,
@@ -43,7 +43,7 @@ CREATE TABLE `sessions` (
   KEY `starttime` (`starttime`,`sensor`)
 ) ;
 
-CREATE TABLE `ttylog` (
+CREATE TABLE IF NOT EXISTS `ttylog` (
   `id` int(11) NOT NULL auto_increment,
   `session` char(32) NOT NULL,
   `ttylog` varchar(100) NOT NULL,
@@ -51,7 +51,7 @@ CREATE TABLE `ttylog` (
   PRIMARY KEY  (`id`)
 ) ;
 
-CREATE TABLE `downloads` (
+CREATE TABLE IF NOT EXISTS `downloads` (
   `id` int(11) NOT NULL auto_increment,
   `session` CHAR( 32 ) NOT NULL,
   `timestamp` datetime NOT NULL,
@@ -60,4 +60,12 @@ CREATE TABLE `downloads` (
   `shasum` varchar(64) default NULL,
   PRIMARY KEY  (`id`),
   KEY `session` (`session`,`timestamp`)
+) ;
+
+CREATE TABLE IF NOT EXISTS `keyfingerprints` (
+  `id` int(11) NOT NULL auto_increment,
+  `session` CHAR( 32 ) NOT NULL,
+  `username` varchar(100) NOT NULL,
+  `fingerprint` varchar(100) NOT NULL,
+  PRIMARY KEY  (`id`)
 ) ;

--- a/doc/sql/update10.sql
+++ b/doc/sql/update10.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `keyfingerprints` (
+  `id` int(11) NOT NULL auto_increment,
+  `session` CHAR( 32 ) NOT NULL,
+  `username` varchar(100) NOT NULL,
+  `fingerprint` varchar(100) NOT NULL,
+  PRIMARY KEY  (`id`),
+) ;

--- a/doc/sql/update9.sql
+++ b/doc/sql/update9.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `ttylog` CHANGE `ttylog` `ttylog` VARCHAR(100) NOT NULL;
+ALTER TABLE `ttylog` ADD `size` INT(11) NOT NULL;


### PR DESCRIPTION
Since the ttylog itself is no longer being stored in the MySQL database (just in log file now on the file system), kippo-graph is unable to figure out the size of the log file. There is a in-built function to kippo-graph to ignore any log file which are under a certain size (useful to hide all the results which are users/bots just logging in and performing no other action). 

Because of the log file being in a different location, this breaks the functionality.

This pull request will add a new column to the database to store the values.

Related pull request for kippo-graph https://github.com/ikoniaris/kippo-graph/pull/42.
