### PR TITLE
Disable JSON logging by default

### DIFF
--- a/cowrie.cfg.dist
+++ b/cowrie.cfg.dist
@@ -222,8 +222,8 @@ interact_port = 5123
 
 # JSON based logging module
 #
-[output_jsonlog]
-logfile = log/cowrie.json
+#[output_jsonlog]
+#logfile = log/cowrie.json
 
 
 # Supports logging to elasticsearch


### PR DESCRIPTION
I believe that if you want cowrie to log in a certain style, it should be edited by the user.

I personally have no need for JSON and have to disable it every time.
