### PR TITLE
Fixed logging of downloads to database

### DIFF
--- a/cowrie/output/mysql.py
+++ b/cowrie/output/mysql.py
@@ -146,7 +146,7 @@ class Output(cowrie.core.output.Output):
         elif entry["eventid"] == 'COW0007':
             self.simpleQuery('INSERT INTO `downloads`' + \
                 ' (`session`, `timestamp`, `url`, `outfile`, `shasum`)' + \
-                ' VALUES (%s, STR_TO_DATE(%s, %s), %s, %s)',
+                ' VALUES (%s, STR_TO_DATE(%s, %s), %s, %s, %s)',
                 (entry["session"], entry["timestamp"], '%Y-%m-%dT%H:%i:%s.%fZ',
                 entry['url'], entry['outfile'], entry['shasum']))
 


### PR DESCRIPTION
Downloads were not logging to the database due to an incorrect number of parameters passed to VALUES
