### PR TITLE
Update start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -26,7 +26,7 @@ then
 fi
 
 echo "Starting cowrie in the background..."
-if [ $AUTHBIND_ENABLED == "no" ]
+if [ $AUTHBIND_ENABLED = "no" ]
 then
     twistd -l log/cowrie.log --pidfile cowrie.pid cowrie
 else


### PR DESCRIPTION
Very small change, POSIX sh doesn't understand == for string equality, bash does, but I'm assuming you went with sh for a reason. I updated it to use = instead.
