### PR TITLE
Able to playback multiple log files back to back

### DIFF
--- a/utils/playlog.py
+++ b/utils/playlog.py
@@ -63,7 +63,7 @@ def playlog(fd, settings):
 
 def help(brief = 0):
 
-    print 'Usage: %s [-bfhi] [-m secs] [-w file] <tty-log-file>\n' % \
+    print 'Usage: %s [-bfhi] [-m secs] [-w file] <tty-log-file> <tty-log-file>...\n' % \
         os.path.basename(sys.argv[0])
 
     if not brief:
@@ -106,11 +106,11 @@ if __name__ == '__main__':
         help()
 
     try:
-        logfd = open(args[0], 'rb')
+        for logfile in args:
+            logfd = open(logfile, 'rb')
+            playlog(logfd, settings)
     except IOError:
-        print "Couldn't open log file!"
+        print "\n\n[!] Couldn't open log file (%s)!" % logfile
         sys.exit(2)
-
-    playlog(logfd, settings)
 
 # vim: set sw=4:


### PR DESCRIPTION
#### Before

```
[root:~/cowrie/utils]$ python playlog.py ../log/tty/20151230-113302-42be9b77-0i.log ../log/tty/20151230-114534-c013f532-0i.log

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.

root@svr04:~# exit
[root:~/cowrie/utils]$
```
#### After

```
[root:~/cowrie/utils]$ python playlog.py ../log/tty/20151230-113302-42be9b77-0i.log ../log/tty/20151230-114534-c013f532-0i.log

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.

root@svr04:~# exit

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.

root@svr04:~# id
uid=0(root) gid=0(root) groups=0(root)
root@svr04:~# exit
[root:~/cowrie/utils]$
```
#### Bonus

... will give the path to the file it cannot find now.

```
[root:~/cowrie/utils]$ python playlog.py ../log/tty/2015123 playback)


[!] Couldn't open log file (../log/tty/2015123)!
[root:~/cowrie/utils]$
```
