### PR TITLE
Remove "\n" in stop.sh.

### DIFF
--- a/stop.sh
+++ b/stop.sh
@@ -7,6 +7,6 @@ cd $(dirname $0)
 PID=$(cat $PIDFILE 2>/dev/null)
 
 if [ -n "$PID" ]; then
-  echo "Stopping cowrie...\n"
+  echo "Stopping cowrie..."
   kill -TERM $PID
 fi


### PR DESCRIPTION
`/bin/sh` don't seems to treat `\` as escape.

![image](https://cloud.githubusercontent.com/assets/6070533/13133898/2db04cbe-d63b-11e5-8b7f-651d24533488.png)
