### PR TITLE
Fix queued command parsing

### DIFF
--- a/cowrie/core/honeypot.py
+++ b/cowrie/core/honeypot.py
@@ -98,7 +98,7 @@ class HoneyPotCommand(object):
         """
         log.msg('QUEUED INPUT: %s' % (line,))
         # FIXME: naive command parsing, see lineReceived below
-        self.protocol.cmdstack[0].cmdpending.append(line)
+        self.protocol.cmdstack[0].cmdpending.append(shlex.split(line))
 
 
     def resume(self):


### PR DESCRIPTION
- do not append line as string, but as list

avoid:

```
        Traceback (most recent call last):
          File "/usr/lib/python2.7/dist-packages/twisted/python/context.py", line 118, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/usr/lib/python2.7/dist-packages/twisted/python/context.py", line 81, in callWithContext
            return func(*args,**kw)
          File "/usr/lib/python2.7/dist-packages/twisted/conch/ssh/service.py", line 44, in packetReceived
            return f(packet)
          File "/usr/lib/python2.7/dist-packages/twisted/conch/ssh/connection.py", line 242, in ssh_CHANNEL_DATA
            log.callWithLogger(channel, channel.dataReceived, data)
        --- <exception caught here> ---
          File "/usr/lib/python2.7/dist-packages/twisted/python/log.py", line 88, in callWithLogger
            return callWithContext({"system": lp}, func, *args, **kw)
          File "/usr/lib/python2.7/dist-packages/twisted/python/log.py", line 73, in callWithContext
            return context.call({ILogContext: newCtx}, func, *args, **kw)
          File "/usr/lib/python2.7/dist-packages/twisted/python/context.py", line 118, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/usr/lib/python2.7/dist-packages/twisted/python/context.py", line 81, in callWithContext
            return func(*args,**kw)
          File "/usr/lib/python2.7/dist-packages/twisted/conch/ssh/session.py", line 107, in dataReceived
            self.client.transport.write(data)
          File "/usr/lib/python2.7/dist-packages/twisted/conch/ssh/session.py", line 158, in write
            self.proto.dataReceived(data)
          File "/home/kippo/honeypot/cowrie.git/cowrie/insults/insults.py", line 105, in dataReceived
            insults.ServerProtocol.dataReceived(self, data)
          File "/usr/lib/python2.7/dist-packages/twisted/conch/insults/insults.py", line 431, in dataReceived
            self.terminalProtocol.keystrokeReceived(ch, None)
          File "/usr/lib/python2.7/dist-packages/twisted/conch/recvline.py", line 199, in keystrokeReceived
            m()
          File "/home/kippo/honeypot/cowrie.git/cowrie/core/protocol.py", line 319, in handle_RETURN
            return recvline.RecvLine.handle_RETURN(self)
          File "/usr/lib/python2.7/dist-packages/twisted/conch/recvline.py", line 257, in handle_RETURN
            self.lineReceived(line)
          File "/home/kippo/honeypot/cowrie.git/cowrie/core/protocol.py", line 168, in lineReceived
            self.cmdstack[-1].lineReceived(line)
          File "/home/kippo/honeypot/cowrie.git/cowrie/core/honeypot.py", line 191, in lineReceived
            self.runCommand()
          File "/home/kippo/honeypot/cowrie.git/cowrie/core/honeypot.py", line 225, in runCommand
            piece = cmdAndArgs.pop(0)
        exceptions.AttributeError: 'str' object has no attribute 'pop'
```
