### PR TITLE
Handle timeouts differently in exec protocol

### DIFF
--- a/cowrie/core/protocol.py
+++ b/cowrie/core/protocol.py
@@ -207,6 +207,12 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
         self.cmdstack[0].lineReceived(self.execcmd)
 
 
+    def timeoutConnection(self):
+        """
+        """
+        ret = failure.Failure(error.ProcessTerminated(exitCode=1))
+        self.terminal.transport.processEnded(ret)
+
 
 class HoneyPotInteractiveProtocol(HoneyPotBaseProtocol, recvline.HistoricRecvLine):
     """

--- a/cowrie/core/protocol.py
+++ b/cowrie/core/protocol.py
@@ -200,7 +200,7 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
         """
         """
         HoneyPotBaseProtocol.connectionMade(self)
-        self.setTimeout(60)
+        self.setTimeout(300)
         self.terminal.stdinlog_open = True
 
         self.cmdstack = [honeypot.HoneyPotShell(self, interactive=False)]


### PR DESCRIPTION
avoids:

```
        Traceback (most recent call last):
          File "/usr/lib/python2.7/dist-packages/twisted/application/app.py", line 392, in startReactor
            self.config, oldstdout, oldstderr, self.profiler, reactor)
          File "/usr/lib/python2.7/dist-packages/twisted/application/app.py", line 313, in runReactorWithLogging
            reactor.run()
          File "/usr/lib/python2.7/dist-packages/twisted/internet/base.py", line 1192, in run
            self.mainLoop()
          File "/usr/lib/python2.7/dist-packages/twisted/internet/base.py", line 1201, in mainLoop
            self.runUntilCurrent()
        --- <exception caught here> ---
          File "/usr/lib/python2.7/dist-packages/twisted/internet/base.py", line 824, in runUntilCurrent
            call.func(*call.args, **call.kw)
          File "/usr/lib/python2.7/dist-packages/twisted/protocols/policies.py", line 719, in __timedOut
            self.timeoutConnection()
          File "/home/kippo/honeypot/cowrie.git/cowrie/core/protocol.py", line 97, in timeoutConnection
            self.terminal.transport.processEnded(ret)
        exceptions.AttributeError: 'NoneType' object has no attribute 'transport'
```
