### PR TITLE
FIXED XMPP

### DIFF
--- a/cowrie/core/dblog.py
+++ b/cowrie/core/dblog.py
@@ -21,7 +21,7 @@ class DBLogger(object):
         self.ttylogs = {}
         #:* Handles ipv6 
         self.re_sessionlog = re.compile(
-            '.*HoneyPotTransport,([0-9]+),:*[fa-z0-9.]+$')
+            '.*HoneyPotTransport,([0-9]+),:*[:fa-z0-9.]+$')
 
         # cowrie.session.connect is special since it kicks off new logging session,
         # and is not handled here

--- a/cowrie/core/dblog.py
+++ b/cowrie/core/dblog.py
@@ -21,7 +21,7 @@ class DBLogger(object):
         self.ttylogs = {}
         #:* Handles ipv6 
         self.re_sessionlog = re.compile(
-            '.*HoneyPotTransport,([0-9]+),:*[0-9.]+$')
+            '.*HoneyPotTransport,([0-9]+),:*[fa-z0-9.]+$')
 
         # cowrie.session.connect is special since it kicks off new logging session,
         # and is not handled here

--- a/cowrie/core/dblog.py
+++ b/cowrie/core/dblog.py
@@ -19,8 +19,9 @@ class DBLogger(object):
         self.cfg = cfg
         self.sessions = {}
         self.ttylogs = {}
+        #:* Handles ipv6 
         self.re_sessionlog = re.compile(
-            '.*HoneyPotTransport,([0-9]+),[0-9.]+$')
+            '.*HoneyPotTransport,([0-9]+),:*[0-9.]+$')
 
         # cowrie.session.connect is special since it kicks off new logging session,
         # and is not handled here

--- a/cowrie/core/honeypot.py
+++ b/cowrie/core/honeypot.py
@@ -298,7 +298,7 @@ class HoneyPotShell(object):
 
                 cmdclass =  self.protocol.getCommand(cmd['command'], environ['PATH'] .split(':'))
                 if cmdclass:
-                    log.msg(eventid='cowrie.command.success', input=' '.join(cmd2), format='Command found: %(input)s')
+                    log.msg(eventid='cowrie.command.success', input=cmd['command'] + "  " + ' '.join(cmd['rargs']), format='Command found: %(input)s')
                     if index == len(cmd_array)-1:
                         lastpp =  StdOutStdErrEmulationProtocol(self.protocol,cmdclass,cmd['rargs'],None,None)
                         pp = lastpp


### PR DESCRIPTION
Include ::1 in ev[system]

Regular Expression wasn't working with ev['system'] causing xmpp not to work (I think its ipv6 related)
