### PR TITLE
[RFR] Fix Uploads to asciinema server.

### DIFF
--- a/bin/asciinema
+++ b/bin/asciinema
@@ -62,10 +62,17 @@ def playlog(fd, settings):
                 if settings['colorify'] and color:
                     sys.stdout.write(color)
 
+                # rtrox: While playback works properly
+                #        with the asciinema client, upload
+                #        causes mangling of the data due to
+                #        newlines being misinterpreted without
+                #        carriage returns.
+                data = data.replace("\n", "\r\n")
+
                 thedata = [sleeptime, data]
                 thelog['duration'] = curtime
                 stdout.append(thedata)
-                
+
                 if settings['colorify'] and color:
                     sys.stdout.write(COLOR_RESET)
                     color = None


### PR DESCRIPTION
In it's current iteration, `bin/asciinema` works properly to allow playback via the local `asciinema` binary, but when `ascinema upload` is used, playback gets destroyed, like this:

[![asciicast](https://asciinema.org/a/bm33i73qxrtcgj2jsr3h5t2p7.png)](https://asciinema.org/a/bm33i73qxrtcgj2jsr3h5t2p7)

After some playing, I discovered that the asciicinema web players expect new lines to be represented with _both_ a new line (`\n`) and a carriage return (`\r`). As the local cowrie binary logs only store `\n`, the player wasn't representing the return.

The same playback log above is represented properly with this fix:

[![asciicast](https://asciinema.org/a/ejud17m8jk48dau7qwvyex4jz.png)](https://asciinema.org/a/ejud17m8jk48dau7qwvyex4jz)

Thanks for Looking!
