### PR TITLE
rewrite of install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,20 @@
-# Installing cowrie in five steps.
+- [Installing cowrie in six steps.](#installing-cowrie-in-six-steps)
+  * [Step 1: Create a user account](#step-1--create-a-user-account)
+  * [Step 2: Checkout the code](#step-2--checkout-the-code)
+  * [Step 3: Setup Dependencies](#step-3--setup-dependencies)
+    + [Option A: Install with Python packages from your Linux Distribution](#option-a--install-with-python-packages-from-your-linux-distribution)
+    + [Option B Install with Python Virtual Environments](#option-b-install-with-python-virtual-environments)
+  * [Step 4: Install configuration file](#step-4--install-configuration-file)
+  * [Step 5: Start](#step-5--start)
+  * [Step 6: Port redirection (optional)](#step-6--port-redirection--optional-)
+  * [Troubleshooting](#troubleshooting)
 
-## Step 1: Create a user account, checkout the code
+<small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
 
-## Add a user
+
+# Installing cowrie in six steps.
+
+## Step 1: Create a user account
 
 It's strongly recommended to install under a dedicated non-root user id:
 
@@ -21,7 +33,11 @@ Other []:
 Is the information correct? [Y/n]
 
 $ sudo su - cowrie
+```
 
+## Step 2: Checkout the code
+
+```
 $ git clone http://github.com/micheloosterhof/cowrie
 Cloning into 'cowrie'...
 remote: Counting objects: 2965, done.
@@ -34,7 +50,7 @@ Checking connectivity... done.
 $ cd cowrie
 ```
 
-## Step 2: Setup Dependencies 
+## Step 3: Setup Dependencies 
 ### Option A: Install with Python packages from your Linux Distribution
 
 Install prerequisites on Debian based systems:
@@ -80,13 +96,13 @@ $ source cowrie-env/bin/activate
 (cowrie-env) $ pip install -r requirements.txt
 ```
 
-## Step 3: Install configuration file
+## Step 4: Install configuration file
 
 ```
 $ cp cowrie.cfg.dist cowrie.cfg
 ```
 
-## Step 4: Start
+## Step 5: Start
 
 Cowrite is implemented as a module for twisted, but to properly import everything the top-level source directory needs to be in os.path.  If you're using a virtual environment this sometimes won't happen correctly, so make it explicit:
 
@@ -107,7 +123,7 @@ $ ./start.sh cowrie-env
 Starting cowrie in the background...
 ```
 
-## Step 5: Port redirection (optional)
+## Step 6: Port redirection (optional)
 
 Cowrie runs by default on port 2222. This can be modified in the configuration file.
 The following firewall rule will forward incoming traffic on port 22 to port 2222.
@@ -130,7 +146,7 @@ $ chmod 770 /etc/authbind/byport/22
 
 ## Troubleshooting
 
-* For some versions of Twisted you may receive the following error messagse:
+* For some versions of Twisted you may receive the following error messages:
 
 ```
 ....

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,7 +69,7 @@ $ sudo pip install enum34
 
 On Debian based systems:
 ```
-$ sudo apt-get install virtualenv libmpfr-dev openssl-dev libmpc-dev libffi-dev
+$ sudo apt-get install virtualenv libmpfr-dev libssl-dev libmpc-dev libffi-dev
 ```
 
 Create a virtual environment

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,12 +57,6 @@ Install prerequisites on Debian based systems:
 $ sudo apt-get install python-twisted python-configparser python-crypto python-pyasn1 python-gmpy2 python-mysqldb python-zope.interface
 ```
 
-Install prerequisites on RedHat based systems:
-
-```
-$ sudo yum install <tbd> <tbd> <tbd>
-```
-
 Install prerequisites on Alpine based systems:
 
 ```
@@ -77,7 +71,6 @@ On Debian based systems:
 ```
 $ sudo apt-get install virtualenv libmpfr-dev openssl-dev libmpc-dev libffi-dev
 ```
-On RedHat based systems you will need the corresponding packages.
 
 Create a virtual environment
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -95,7 +95,7 @@ $ cp cowrie.cfg.dist cowrie.cfg
 
 ## Step 5: Start
 
-Cowrite is implemented as a module for twisted, but to properly import everything the top-level source directory needs to be in os.path.  If you're using a virtual environment this sometimes won't happen correctly, so make it explicit:
+Cowrite is implemented as a module for twisted, but to properly import everything the top-level source directory needs to be in os.path.  This sometimes won't happen correctly, so make it explicit:
 
 ```
 $ export PYTHONPATH=/path/to/cowrie

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,9 +20,9 @@ There are two ways to install cowrie: with a python virtual environment, or dire
 
 ### Option A: dependencies for virtualenv
 
-On Debian based systems (tested on Debian 8):
+On Debian based systems (tested on Debian 8 8/30/2016):
 ```
-$ sudo apt-get git install virtualenv libmpfr-dev libssl-dev libmpc-dev libffi-dev build-essential libpython-dev
+$ sudo apt-get install git virtualenv libmpfr-dev libssl-dev libmpc-dev libffi-dev build-essential libpython-dev
 ```
 
 
@@ -31,7 +31,7 @@ $ sudo apt-get git install virtualenv libmpfr-dev libssl-dev libmpc-dev libffi-d
 Install prerequisites on Debian based systems (untested 8/30/2016):
 
 ```
-$ sudo apt-get git install python-twisted python-configparser python-crypto python-pyasn1 python-gmpy2 python-mysqldb python-zope.interface
+$ sudo apt-get install git python-twisted python-configparser python-crypto python-pyasn1 python-gmpy2 python-mysqldb python-zope.interface
 ```
 
 Install prerequisites on Alpine based systems (untested 8/30/2016):
@@ -109,7 +109,7 @@ $ cp cowrie.cfg.dist cowrie.cfg
 This step should not be necessary, however some versions of twisted are not compatible.  To avoid problems in advance, run:
 
 ```
-$ cd cowrie/data
+$ cd data
 $ ssh-keygen -t dsa -b 1024 -f ssh_host_dsa_key
 $ cd ..
 ```
@@ -119,7 +119,8 @@ $ cd ..
 Cowrite is implemented as a module for twisted, but to properly import everything the top-level source directory needs to be in python's os.path.  This sometimes won't happen correctly, so make it explicit:
 
 ```
-$ export PYTHONPATH=/path/to/cowrie
+# or whatever path to the top-level cowrie folder
+$ export PYTHONPATH=/home/cowrie/cowrie
 ```
 
 In the absence of a virtual environment, you may run:
@@ -128,7 +129,7 @@ In the absence of a virtual environment, you may run:
 $ ./start.sh
 ```
 
-When using Python Virtual Environments you can add the name of the venv as the first argument
+When using Python Virtual Environments you should add the name of the venv as the first argument
 
 ```
 $ ./start.sh cowrie-env
@@ -144,7 +145,7 @@ The following firewall rule will forward incoming traffic on port 22 to port 222
 $ sudo iptables -t nat -A PREROUTING -p tcp --dport 22 -j REDIRECT --to-port 2222
 ```
 
-Alternatively you can run authbind to listen as non-root on port 22 directly:
+Note that you should test this rule only from another host; it doesn't apply to loopback connections.  Alternatively you can run authbind to listen as non-root on port 22 directly:
 
 ```
 $ apt-get install authbind

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,52 +1,6 @@
-# Installing cowrie in six easy steps.
+# Installing cowrie in five steps.
 
-## Install with Python packages from your Linux Distribution
-
-Install prerequisites on Debian based systems:
-
-```
-$ sudo apt-get install python-twisted python-configparser python-crypto python-pyasn1 python-gmpy2 python-mysqldb python-zope.interface
-```
-
-Install prerequisites on RedHat based systems:
-
-```
-$ sudo yum install <tbd> <tbd> <tbd>
-```
-
-Install prerequisites on Alpine based systems:
-
-```
-$ sudo apk add python py-asn1 py-twisted py-zope-interface libffi-dev \
-        py-cryptography py-pip py-six py-cffi py-idna py-ipaddress py-openssl
-$ sudo pip install enum34
-```
-
-## Install with Python Virtual Environments
-
-On Debian based systems:
-```
-$ sudo apt-get install virtualenv libmpfr-dev
-```
-On RedHat based systems:
-```
-$ sudo yum install virtualenv libmpfr-devel
-```
-
-Create a virtual environment
-
-```
-$ virtualenv cowrie-env
-New python executable in ./cowrie/cowrie-env/bin/python
-Installing setuptools, pip, wheel...done.
-```
-
-Activate the virtual environment and install packages
-
-```
-$ source cowrie-env/bin/activate
-(cowrie-env) $ pip install -r requirements.txt
-```
+## Step 1: Create a user account, checkout the code
 
 ## Add a user
 
@@ -78,18 +32,82 @@ Resolving deltas: 100% (1908/1908), done.
 Checking connectivity... done.
 
 $ cd cowrie
-
-$ cp cowrie.cfg.dist cowrie.cfg
-
-$ ./start.sh
-Starting cowrie in the background...
 ```
+
+## Step 2: Setup Dependencies 
+### Option A: Install with Python packages from your Linux Distribution
+
+Install prerequisites on Debian based systems:
+
+```
+$ sudo apt-get install python-twisted python-configparser python-crypto python-pyasn1 python-gmpy2 python-mysqldb python-zope.interface
+```
+
+Install prerequisites on RedHat based systems:
+
+```
+$ sudo yum install <tbd> <tbd> <tbd>
+```
+
+Install prerequisites on Alpine based systems:
+
+```
+$ sudo apk add python py-asn1 py-twisted py-zope-interface libffi-dev \
+        py-cryptography py-pip py-six py-cffi py-idna py-ipaddress py-openssl
+$ sudo pip install enum34
+```
+
+### Option B Install with Python Virtual Environments
+
+On Debian based systems:
+```
+$ sudo apt-get install virtualenv libmpfr-dev openssl-dev libmpc-dev libffi-dev
+```
+On RedHat based systems you will need the corresponding packages.
+
+Create a virtual environment
+
+```
+$ virtualenv cowrie-env
+New python executable in ./cowrie/cowrie-env/bin/python
+Installing setuptools, pip, wheel...done.
+```
+
+Activate the virtual environment and install packages
+
+```
+$ source cowrie-env/bin/activate
+(cowrie-env) $ pip install -r requirements.txt
+```
+
+## Step 3: Install configuration file
+
+```
+$ cp cowrie.cfg.dist cowrie.cfg
+```
+
+## Step 4: Start
+
+Cowrite is implemented as a module for twisted, but to properly import everything the top-level source directory needs to be in os.path.  If you're using a virtual environment this sometimes won't happen correctly, so make it explicit:
+
+```
+$ export PYTHONPATH=/path/to/cowrie
+```
+
+In the absence of a virtual environment, you may run:
+
+```
+$ ./start.sh
+```
+
 When using Python Virtual Environments you can add the name of the venv as the first argument
 
 ```
 $ ./start.sh cowrie-env
 Starting cowrie in the background...
 ```
+
+## Step 5: Port redirection (optional)
 
 Cowrie runs by default on port 2222. This can be modified in the configuration file.
 The following firewall rule will forward incoming traffic on port 22 to port 2222.
@@ -110,7 +128,7 @@ $ chmod 770 /etc/authbind/byport/22
 * Edit start.sh and modify the AUTHBIND_ENABLED setting
 * Change listen_port to 22 in cowrie.cfg
 
-## Bugs and workarounds
+## Troubleshooting
 
 * For some versions of Twisted you may receive the following error messagse:
 
@@ -128,6 +146,7 @@ $ cd cowrie/data
 $ ssh-keygen -t dsa -b 1024 -f ssh_host_dsa_key
 ```
 
+* If you see `twistd: Unknown command: cowrie` there are two possibilities.  If there's a python stack trace, it probably means there's a missing dependency.  If there's no stack trace, double check that your PYTHONPATH is set to the source code directory.
 * Default file permissions
 
 To make Cowrie logfiles public readable, change the ```--umask 0077``` option in start.sh into ```--umask 0022```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,16 +1,16 @@
-- [Installing cowrie in six steps.](#installing-cowrie-in-six-steps)
+
+# Installing cowrie in six steps.
+
   * [Step 1: Create a user account](#step-1--create-a-user-account)
   * [Step 2: Checkout the code](#step-2--checkout-the-code)
   * [Step 3: Setup Dependencies](#step-3--setup-dependencies)
     + [Option A: Install with Python packages from your Linux Distribution](#option-a--install-with-python-packages-from-your-linux-distribution)
-    + [Option B Install with Python Virtual Environments](#option-b-install-with-python-virtual-environments)
+    + [Option B: Install with Python Virtual Environments](#option-b-install-with-python-virtual-environments)
   * [Step 4: Install configuration file](#step-4--install-configuration-file)
   * [Step 5: Start](#step-5--start)
   * [Step 6: Port redirection (optional)](#step-6--port-redirection--optional-)
   * [Troubleshooting](#troubleshooting)
 
-
-# Installing cowrie in six steps.
 
 ## Step 1: Create a user account
 
@@ -71,7 +71,7 @@ $ sudo apk add python py-asn1 py-twisted py-zope-interface libffi-dev \
 $ sudo pip install enum34
 ```
 
-### Option B Install with Python Virtual Environments
+### Option B: Install with Python Virtual Environments
 
 On Debian based systems:
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,8 +9,6 @@
   * [Step 6: Port redirection (optional)](#step-6--port-redirection--optional-)
   * [Troubleshooting](#troubleshooting)
 
-<small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
-
 
 # Installing cowrie in six steps.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ configparser
 pyopenssl
 gmpy2
 service_identity
+pycrypto


### PR DESCRIPTION
I had a really frustrating experience installing cowrie today.  I'm normally pretty good at these kinds of things but there were lots of gotchas: unlisted dependencies, needing to set python's os.path properly (this took a long time to figure out!), and generally finding the documentation confusing.  There was also a missing dependency in requirements.txt.  For someone like myself who isn't familiar with python packaging, pip and so on, this can be quite an ordeal.

I'm hoping this rewrite of the install instructions will help.  I've tested that the new instructions work perfectly command-by-command on a fresh install of Debian 8 using virtualenv.  If anything I've said isn't quite right, please let me know and I'll fix it.

Thank you for developing such a nice tool!  I think I'm going to be having some fun with this.
