### PR TITLE
Various improvements for automated attacks

### DIFF
--- a/cowrie/commands/busybox.py
+++ b/cowrie/commands/busybox.py
@@ -61,36 +61,26 @@ class command_busybox(HoneyPotCommand):
     def call(self):
         """
         """
-        start_value = None
-        parsed_arguments = []
-        for count in range(0,len(self.args)):
-            class_found = self.protocol.getCommand(self.args[count], self.environ['PATH'].split(':'))
-            if class_found:
-                start_value = count
-                break
-        if start_value is not None:
-            for index_2 in range(start_value,len(self.args)):
-                parsed_arguments.append(self.args[index_2])
-
-        if len(parsed_arguments) > 0:
-            line = ' '.join(parsed_arguments)
-            cmd = parsed_arguments[0]
-            cmdclass = self.protocol.getCommand(cmd,
-                                                self.environ['PATH'].split(':'))
-            if cmdclass:
-                log.msg(eventid='cowrie.command.success',
-                        input=line,
-                        format='Command found: %(input)s')
-                command = StdOutStdErrEmulationProtocol(self.protocol,cmdclass,parsed_arguments[1:],self.input_data,None)
-                self.protocol.pp.insert_command(command)
-                # Place this here so it doesn't write out only if last statement
-
-                if self.input_data:
-                    self.write(self.input_data)
-            else:
-                self.write('{}: applet not found\n'.format(cmd))
-        else:
+        if len(self.args) == 0:
             self.help()
+            return
+
+        line = ' '.join(self.args)
+        cmd = self.args[0]
+        cmdclass = self.protocol.getCommand(cmd,
+                                            self.environ['PATH'].split(':'))
+        if cmdclass:
+            log.msg(eventid='cowrie.command.success',
+                    input=line,
+                    format='Command found: %(input)s')
+            command = StdOutStdErrEmulationProtocol(self.protocol,cmdclass,self.args[1:],self.input_data,None)
+            self.protocol.pp.insert_command(command)
+            # Place this here so it doesn't write out only if last statement
+
+            if self.input_data:
+                self.write(self.input_data)
+        else:
+            self.write('{}: applet not found\n'.format(cmd))
 
 commands['busybox'] = command_busybox
 commands['/bin/busybox'] = command_busybox

--- a/cowrie/commands/busybox.py
+++ b/cowrie/commands/busybox.py
@@ -88,7 +88,7 @@ class command_busybox(HoneyPotCommand):
                 if self.input_data:
                     self.write(self.input_data)
             else:
-                self.help()
+                self.write('{}: applet not found\n'.format(cmd))
         else:
             self.help()
 

--- a/cowrie/commands/fs.py
+++ b/cowrie/commands/fs.py
@@ -555,5 +555,6 @@ class command_touch(HoneyPotCommand):
 
 commands['/usr/bin/touch'] = command_touch
 commands['/bin/touch'] = command_touch
+commands['>'] = command_touch
 
 # vim: set sw=4 et:

--- a/cowrie/core/fs.py
+++ b/cowrie/core/fs.py
@@ -168,15 +168,6 @@ class HoneyPotFilesystem(object):
             f[A_REALFILE] = realfile
 
 
-    def realfile(self, f, path):
-        """
-        """
-        self.update_realfile(f, path)
-        if f[A_REALFILE]:
-            return f[A_REALFILE]
-        return None
-
-
     def getfile(self, path, follow_symlinks=True):
         """
         This returns the Cowrie file system object for a path
@@ -223,12 +214,11 @@ class HoneyPotFilesystem(object):
         f = self.getfile(path)
         if f[A_TYPE] == T_DIR:
             raise IsADirectoryError
-        elif f[A_TYPE] == T_FILE and f[A_REALFILE]:
-            return file(f[A_REALFILE], 'rb').read()
-        realfile = self.realfile(f, '%s/%s' % \
-            (self.cfg.get('honeypot', 'contents_path'), path))
-        if realfile:
-            return file(realfile, 'rb').read()
+        elif f[A_TYPE] == T_FILE:
+            self.update_realfile(f, '%s/%s' % \
+                (self.cfg.get('honeypot', 'contents_path'), path))
+            if f[A_REALFILE]:
+                return file(f[A_REALFILE], 'rb').read()
 
 
     def mkfile(self, path, uid, gid, size, mode, ctime=None):

--- a/cowrie/core/fs.py
+++ b/cowrie/core/fs.py
@@ -235,6 +235,11 @@ class HoneyPotFilesystem(object):
             raise IsADirectoryError
         elif f[A_TYPE] == T_FILE and f[A_REALFILE]:
             return file(f[A_REALFILE], 'rb').read()
+        elif f[A_TYPE] == T_FILE and f[A_SIZE] == 0:
+            # Zero-byte file lacking A_REALFILE backing: probably empty.
+            # (The exceptions to this are some system files in /proc and /sys,
+            # but it's likely better to return nothing than suspiciously fail.)
+            return ''
 
 
     def mkfile(self, path, uid, gid, size, mode, ctime=None):

--- a/cowrie/core/fs.py
+++ b/cowrie/core/fs.py
@@ -211,22 +211,18 @@ class HoneyPotFilesystem(object):
         return p
 
 
-    def file_contents(self, target, count=0):
+    def file_contents(self, target):
         """
         Retrieve the content of a file in the honeyfs
         It follows links.
         It tries A_REALFILE first and then tries honeyfs directory
         """
-        if count > 8:
-            raise TooManyLevels
         path = self.resolve_path(target, os.path.dirname(target))
         if not path or not self.exists(path):
             raise FileNotFound
         f = self.getfile(path)
         if f[A_TYPE] == T_DIR:
             raise IsADirectoryError
-        elif f[A_TYPE] == T_LINK:
-            return self.file_contents(f[A_TARGET], count + 1)
         elif f[A_TYPE] == T_FILE and f[A_REALFILE]:
             return file(f[A_REALFILE], 'rb').read()
         realfile = self.realfile(f, '%s/%s' % \

--- a/cowrie/test/test_base_commands.py
+++ b/cowrie/test/test_base_commands.py
@@ -7,8 +7,7 @@ from twisted.trial import unittest
 
 from cowrie.core import protocol
 from cowrie.core import config
-import fake_server
-import fake_transport
+from cowrie.test import fake_server, fake_transport
 import json
 
 


### PR DESCRIPTION
Hi! Thanks for Cowrie. I'm currently using it to analyze worms and other automated threats, which require very particular behavior from certain commands, and unlike humans, cannot simply try something else when the command they're attempting doesn't work.

4 of the commits in this PR primarily address a bug in the filesystem: currently, if you attempt to read a symlink to a honeyfs file, or copy/move a honeyfs file to a new path before reading it the first time, the contents will not be found. This is because the honeyfs is lazily checked for the realfile on the first access to the virtual file's contents, and the path is used to explore the honeyfs. This change makes Cowrie scan `honeyfs/` whenever a new connection is made, and set the realfile mappings at that time.

The other 3 commits are an assortment of minor tweaks. In particular, the restructuring of Busybox should probably be scrutinized far more heavily as I'm largely reverting the changes in 115048aae8dac4005d38764ff3923d32ae079a8f. This commit _seems_ intended to modify sudo so it can skip over flags and find the command, but as Busybox doesn't accept flags (that I know of), it seems like a reasonable assumption to accept the first argument as the applet, but at the same time I might be missing something. :)

Since these really are basically 2 separate changes in one PR, let me know if you'd like me to separate them.
