### PR TITLE
Add pycrypto to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ configparser
 pyopenssl
 gmpy2
 service_identity
-crypto
 pycrypto

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyopenssl
 gmpy2
 service_identity
 crypto
+pycrypto


### PR DESCRIPTION
Hi there,

In my case, when following the instructions on the cowrie installation page, I got this error:

```
(cowrie-env)cowrie@hostname:~/cowrie$ ./start.sh cowrie-env
Activating virtualenv "cowrie-env"
Starting cowrie with extra arguments [] ...
An error has occurred: b'ImportError: No module named Crypto.PublicKey'
Please look at log file for more information.
```

I am not sure why this happens, and nobody else has opened an issue for this bug, but the solution is simple so I thought I'd make a PR.

Cheers,
Pedro
