### PR TITLE
Fix regression when "cat > file" data wasn't hashed at connection lose.

### DIFF
--- a/cowrie/core/protocol.py
+++ b/cowrie/core/protocol.py
@@ -222,7 +222,7 @@ class HoneyPotExecProtocol(HoneyPotBaseProtocol):
         """
         HoneyPotBaseProtocol.connectionMade(self)
         self.setTimeout(60)
-        self.terminal.stdinlog_open = True
+        self.terminal.stdinlogOpen = True
 
         self.cmdstack = [honeypot.HoneyPotShell(self, interactive=False)]
         self.cmdstack[0].lineReceived(self.execcmd)

--- a/cowrie/insults/insults.py
+++ b/cowrie/insults/insults.py
@@ -68,7 +68,7 @@ class LoggingServerProtocol(insults.ServerProtocol):
         self.stdinlogFile = '%s/%s-%s-%s-stdin.log' % \
             (self.downloadPath,
             time.strftime('%Y%m%d-%H%M%S'), transportId, channelId)
-        self.stdinlogOpen = True
+        self.stdinlogOpen = False
 
         insults.ServerProtocol.connectionMade(self)
 

--- a/cowrie/insults/insults.py
+++ b/cowrie/insults/insults.py
@@ -68,7 +68,7 @@ class LoggingServerProtocol(insults.ServerProtocol):
         self.stdinlogFile = '%s/%s-%s-%s-stdin.log' % \
             (self.downloadPath,
             time.strftime('%Y%m%d-%H%M%S'), transportId, channelId)
-        self.stdinlogOpen = False
+        self.stdinlogOpen = True
 
         insults.ServerProtocol.connectionMade(self)
 


### PR DESCRIPTION
At this moment, there is no way self.stdinlogOpen would be set to True.
