### PR TITLE
Add hashing for binaries saved via redirection.

### DIFF
--- a/cowrie/core/protocol.py
+++ b/cowrie/core/protocol.py
@@ -190,9 +190,11 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         obj.set_input_data(pp.input_data)
         self.cmdstack.append(obj)
         obj.start()
-        if hasattr(obj, 'safeoutfile'):
-            self.terminal.redirlogOpen = True
-            self.terminal.redirlogFile = obj.safeoutfile
+        # don't save redir content if we deal with ExecProtocol (data will be saved as stdin)
+        if not isinstance(self, HoneyPotExecProtocol):
+            if hasattr(obj, 'safeoutfile'):
+                self.terminal.redirlogOpen = True
+                self.terminal.redirlogFile = obj.safeoutfile
         self.pp.outConnectionLost()
 
 

--- a/cowrie/core/protocol.py
+++ b/cowrie/core/protocol.py
@@ -190,6 +190,9 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         obj.set_input_data(pp.input_data)
         self.cmdstack.append(obj)
         obj.start()
+        if hasattr(obj, 'safeoutfile'):
+            self.terminal.redirlogOpen = True
+            self.terminal.redirlogFile = obj.safeoutfile
         self.pp.outConnectionLost()
 
 

--- a/cowrie/insults/insults.py
+++ b/cowrie/insults/insults.py
@@ -22,6 +22,7 @@ class LoggingServerProtocol(insults.ServerProtocol):
     """
     stdinlogOpen = False
     ttylogOpen = False
+    redirlogOpen = False  # it will be set at base/protocol.py
 
     def __init__(self, prot=None, *a, **kw):
         insults.ServerProtocol.__init__(self, prot, *a, **kw)
@@ -31,6 +32,8 @@ class LoggingServerProtocol(insults.ServerProtocol):
 
         self.ttylogPath = cfg.get('honeypot', 'log_path')
         self.downloadPath = cfg.get('honeypot', 'download_path')
+
+        self.redirlogFile = None  # it will be set at base/protocol.py
 
         try:
             self.bytesReceivedLimit = int(cfg.get('honeypot',
@@ -166,6 +169,26 @@ class LoggingServerProtocol(insults.ServerProtocol):
                 pass
             finally:
                 self.stdinlogOpen = False
+
+        if self.redirlogOpen:
+            try:
+                with open(self.redirlogFile, 'rb') as f:
+                    shasum = hashlib.sha256(f.read()).hexdigest()
+                    shasumfile = self.downloadPath + "/" + shasum
+                    if (os.path.exists(shasumfile)):
+                        os.remove(self.redirlogFile)
+                    else:
+                        os.rename(self.redirlogFile, shasumfile)
+                    os.symlink(shasum, self.redirlogFile)
+                log.msg(eventid='cowrie.session.file_download',
+                        format='Saved redir contents to %(outfile)s',
+                        url='redir',
+                        outfile=shasumfile,
+                        shasum=shasum)
+            except IOError as e:
+                pass
+            finally:
+                self.redirlogOpen = False
 
         if self.ttylogOpen:
             # TODO: Add session duration to this entry

--- a/cowrie/insults/insults.py
+++ b/cowrie/insults/insults.py
@@ -22,7 +22,7 @@ class LoggingServerProtocol(insults.ServerProtocol):
     """
     stdinlogOpen = False
     ttylogOpen = False
-    redirlogOpen = False  # it will be set at base/protocol.py
+    redirlogOpen = False  # it will be set at core/protocol.py
 
     def __init__(self, prot=None, *a, **kw):
         insults.ServerProtocol.__init__(self, prot, *a, **kw)
@@ -33,7 +33,7 @@ class LoggingServerProtocol(insults.ServerProtocol):
         self.ttylogPath = cfg.get('honeypot', 'log_path')
         self.downloadPath = cfg.get('honeypot', 'download_path')
 
-        self.redirlogFile = None  # it will be set at base/protocol.py
+        self.redirlogFile = None  # it will be set at core/protocol.py
 
         try:
             self.bytesReceivedLimit = int(cfg.get('honeypot',


### PR DESCRIPTION
Hey,

I hope it's the last fix in the row of my fixes related to saving binaries via echo command :)

This one adds hashing of the binary, created by redirection of output of a command. Hashing/logging is performed in the similar way as with stdin-binaries (on the event connectionLost).

The commit related to the 2th, 3rd issues of #300. Let me know if it's okey, or maybe you want me to merge here other fixes related to the redirection.