### PR TITLE
Remove redundant space, handle double slashes in escape string

### DIFF
--- a/cowrie/commands/base.py
+++ b/cowrie/commands/base.py
@@ -140,7 +140,7 @@ class command_echo(HoneyPotCommand):
         # FIXME: Wrap in exception, Python escape cannot handle single digit \x codes (e.g. \x1)
         try:
             self.write(escape_fn(re.sub('(?<=\\\\)x([0-9a-fA-F]{1})(?=\\\\|\"|\'|\s|$)', 'x0\g<1>',
-                ' '.join(args))).strip('\"\''))
+                ''.join(args).replace('\\\\x', '\\x'))).strip('\"\''))
         except ValueError as e:
             log.msg("echo command received Python incorrect hex escape")
 


### PR DESCRIPTION
The patch handles double slash in escape string. The usage of such string I've seen in the wild:

`echo -e \\x56\\x44\\x4f\\x53\\x53`

Expected result is "VDOSS" (my real linux system produces it), but without patch cowrie outputs "\x56\x44\x4f\x53\x53".

I failed to find more elegant way to fix it, so I've used the straightforward way :)