### PR TITLE
problem: csirtg.io plugin outputs too much debug information

### DIFF
--- a/cowrie.cfg.dist
+++ b/cowrie.cfg.dist
@@ -438,4 +438,5 @@ logfile = log/cowrie.json
 #[output_csirtg]
 #username=wes
 #feed=scanners
+#description=random scanning activity
 #token=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef

--- a/cowrie/output/csirtg.py
+++ b/cowrie/output/csirtg.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 USERNAME = os.environ.get('CSIRTG_USER')
 FEED = os.environ.get('CSIRTG_FEED')
 TOKEN = os.environ.get('CSIRG_TOKEN')
+DESCRIPTION = os.environ.get('CSIRTG_DESCRIPTION', 'random scanning activity')
 
 
 class Output(cowrie.core.output.Output):
@@ -20,6 +21,10 @@ class Output(cowrie.core.output.Output):
         self.user = cfg.get('output_csirtg', 'username') or USERNAME
         self.feed = cfg.get('output_csirtg', 'feed') or FEED
         self.token = cfg.get('output_csirtg', 'token') or TOKEN
+        try:
+            self.description = cfg.get('output_csirtg', 'description')
+        except Exception:
+            self.description = DESCRIPTION
         self.port = os.environ.get('COWRIE_PORT', 22)
         self.context = {}
         self.client = Client(token=self.token)
@@ -54,7 +59,8 @@ class Output(cowrie.core.output.Output):
                 'protocol': 'tcp',
                 'tags': 'scanner,ssh',
                 'firsttime': ts,
-                'lasttime': ts
+                'lasttime': ts,
+                'description': self.description
             }
 
             ret = Indicator(self.client, i).submit()

--- a/cowrie/output/csirtg.py
+++ b/cowrie/output/csirtg.py
@@ -36,10 +36,10 @@ class Output(cowrie.core.output.Output):
         ts = e['timestamp']
 
         today = str(datetime.now().date())
-        logger.info('today is %s' % today)
+        logger.debug('today is %s' % today)
 
         if not self.context.get(today):
-            logger.info('resetting context for %s' % today)
+            logger.debug('resetting context for %s' % today)
             self.context = {}
             self.context[today] = {}
 
@@ -60,6 +60,5 @@ class Output(cowrie.core.output.Output):
             ret = Indicator(self.client, i).submit()
 
             logger.info('logged to csirtg %s ' % ret['indicator']['location'])
-        else:
-            pprint(self.context)
+
         self.context[today][peerIP].append(sid)


### PR DESCRIPTION
solution: convert the unneeded stmts to logger.debug and remove the pprint statement, also fixing default description