### PR TITLE
Fix unit tests to work with new directory structure in develop branch

### DIFF
--- a/cowrie/test/test_base_commands.py
+++ b/cowrie/test/test_base_commands.py
@@ -10,12 +10,17 @@ from cowrie.core import config
 from cowrie.test import fake_server, fake_transport
 import json
 
+import os
+import shutil
 
 
 class ShellBaseCommandsTests(unittest.TestCase):
 
 
     def setUp(self):
+        if '_trial_temp' in os.getcwd():
+            if not os.path.exists('etc'):
+                shutil.copytree('../etc', 'etc')
         with open('../cowrie/test/expected_results.json') as data_file:
             self.data = json.load(data_file)
         self.cfg = config.readConfigFile("../cowrie/test/unittests.cfg")
@@ -202,6 +207,9 @@ class ShellBaseCommandsTests(unittest.TestCase):
 
 class ShellFileCommandsTests(unittest.TestCase):
     def setUp(self):
+        if '_trial_temp' in os.getcwd():
+            if not os.path.exists('etc'):
+                shutil.copytree('../etc', 'etc')
         self.cfg = config.readConfigFile("../cowrie/test/unittests.cfg")
         self.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer(self.cfg)))
@@ -276,6 +284,9 @@ class ShellFileCommandsTests(unittest.TestCase):
 
 class ShellPipeCommandsTests(unittest.TestCase):
     def setUp(self):
+        if '_trial_temp' in os.getcwd():
+            if not os.path.exists('etc'):
+                shutil.copytree('../etc', 'etc')
         self.cfg = config.readConfigFile("../cowrie/test/unittests.cfg")
         self.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer(self.cfg)))

--- a/cowrie/test/unittests.cfg
+++ b/cowrie/test/unittests.cfg
@@ -70,7 +70,7 @@ filesystem_file = ../share/cowrie/fs.pickle
 # In addition to this, the file must exist in the virtual filesystem
 #
 # (default: txtcmds)
-txtcmds_path = ../txtcmds
+txtcmds_path = ../share/cowrie/txtcmds
 
 
 # Maximum file size (in bytes) for downloaded files to be stored in 'download_path'.
@@ -224,10 +224,10 @@ ssh_version_string = SSH-2.0-OpenSSH_6.0p1 Debian-4+deb7u2
 
 # Public and private SSH key files. If these don't exist, they are created
 # automatically.
-rsa_public_key = data/ssh_host_rsa_key.pub
-rsa_private_key = data/ssh_host_rsa_key
-dsa_public_key = data/ssh_host_dsa_key.pub
-dsa_private_key = data/ssh_host_dsa_key
+rsa_public_key = ../data/ssh_host_rsa_key.pub
+rsa_private_key = ../data/ssh_host_rsa_key
+dsa_public_key = ../data/ssh_host_dsa_key.pub
+dsa_private_key = ../data/ssh_host_dsa_key
 
 
 # sftp_enabled enables the sftp subsystem


### PR DESCRIPTION
If tests are running through trial, copy etc directory to _trial_temp so userdb.txt and other files are accessible to the unit tests and don't get modified by the tests