### PR TITLE
Improve handling of ImportErrors to notify users that they need to install new dependencies

### DIFF
--- a/requirements-output.txt
+++ b/requirements-output.txt
@@ -1,0 +1,20 @@
+# output_csirtg:
+csirtgsdk>=0.0.0a6 # Specify version because pip won't install pre-release versions by default
+
+# output_dshield:
+requests
+
+# output_elasticsearch
+pyes
+
+# output_mysql
+MySQL-python
+
+# output_rethinkdblog
+rethinkdb
+
+# output_slack
+slackclient
+
+# output_splunklegacy
+splunk-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pycrypto
 python-dateutil
 tftpy
 csirtgsdk
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,3 @@ service_identity
 pycrypto
 python-dateutil
 tftpy
-csirtgsdk
-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ service_identity
 pycrypto
 python-dateutil
 tftpy
+requests

--- a/twisted/plugins/cowrie_plugin.py
+++ b/twisted/plugins/cowrie_plugin.py
@@ -66,8 +66,8 @@ class Options(usage.Options):
 def importFailureObserver(event):
     if 'failure' in event and event['failure'].type is ImportError:
         log.err("ERROR: %s. Please run `pip install -U -r requirements.txt` "
-                "from Cowrie's install directory (and virtualenv if used) to "
-                "install the new dependency" % event['failure'].value.message)
+                "from Cowrie's install directory and virtualenv to install "
+                "the new dependency" % event['failure'].value.message)
 
 
 globalLogPublisher.addObserver(importFailureObserver)

--- a/twisted/plugins/cowrie_plugin.py
+++ b/twisted/plugins/cowrie_plugin.py
@@ -32,7 +32,7 @@ FIXME: This module contains ...
 
 from __future__ import print_function
 
-from zope.interface import implementer
+from zope.interface import implementer, provider
 
 import os
 import sys
@@ -42,6 +42,7 @@ from twisted.plugin import IPlugin
 from twisted.application.service import IServiceMaker
 from twisted.application import internet, service
 from twisted.cred import portal
+from twisted.logger import ILogObserver, globalLogPublisher
 
 from cowrie.core.config import readConfigFile
 from cowrie import core
@@ -60,6 +61,16 @@ class Options(usage.Options):
         ["config", "c", 'etc/cowrie.cfg', "The configuration file to use."]
         ]
 
+
+@provider(ILogObserver)
+def importFailureObserver(event):
+    if 'failure' in event and event['failure'].type is ImportError:
+        log.err("ERROR: %s. Please run `pip install -U -r requirements.txt` "
+                "from Cowrie's install directory to install the new dependency" %
+                event['failure'].value.message)
+
+
+globalLogPublisher.addObserver(importFailureObserver)
 
 
 @implementer(IServiceMaker, IPlugin)
@@ -125,7 +136,7 @@ class CowrieServiceMaker(object):
                 log.addObserver(output.emit)
                 self.output_plugins.append(output)
                 log.msg("Loaded output engine: {}".format(engine))
-            except:
+            except Exception:
                 log.err()
                 log.msg("Failed to load output engine: {}".format(engine))
 

--- a/twisted/plugins/cowrie_plugin.py
+++ b/twisted/plugins/cowrie_plugin.py
@@ -136,6 +136,9 @@ class CowrieServiceMaker(object):
                 log.addObserver(output.emit)
                 self.output_plugins.append(output)
                 log.msg("Loaded output engine: {}".format(engine))
+            except ImportError as e:
+                log.err("Failed to load output engine: {} due to ImportError: {}".format(engine, e))
+                log.msg("Please install the dependencies for {} listed in requirements-output.txt".format(engine))
             except Exception:
                 log.err()
                 log.msg("Failed to load output engine: {}".format(engine))

--- a/twisted/plugins/cowrie_plugin.py
+++ b/twisted/plugins/cowrie_plugin.py
@@ -66,8 +66,8 @@ class Options(usage.Options):
 def importFailureObserver(event):
     if 'failure' in event and event['failure'].type is ImportError:
         log.err("ERROR: %s. Please run `pip install -U -r requirements.txt` "
-                "from Cowrie's install directory to install the new dependency" %
-                event['failure'].value.message)
+                "from Cowrie's install directory (and virtualenv if used) to "
+                "install the new dependency" % event['failure'].value.message)
 
 
 globalLogPublisher.addObserver(importFailureObserver)


### PR DESCRIPTION
This is the same as #389 but on develop, and #368 but without the extra commits from updating the old branch.