### PR TITLE
Refuse to enable SGA and LINEMODE during authentication

### DIFF
--- a/cowrie/telnet/transport.py
+++ b/cowrie/telnet/transport.py
@@ -180,15 +180,17 @@ class HoneyPotTelnetAuthProtocol(AuthenticatingTelnetProtocol):
         if opt == ECHO:
             return True
         elif opt == SGA:
-            return True
+            return False
+            #return True
         else:
             return False
 
 
     def enableRemote(self, opt):
         if opt == LINEMODE:
-            self.transport.requestNegotiation(LINEMODE, MODE + chr(TRAPSIG))
-            return True
+            return False
+            #self.transport.requestNegotiation(LINEMODE, MODE + chr(TRAPSIG))
+            #return True
         elif opt == NAWS:
             return True
         elif opt == SGA:


### PR DESCRIPTION
Some telnet clients attempt to initiate negotiation about SGA and LINEMODE themselves, but only when a port isn't specified on the command line. If we allow them to enable SGA or LINEMODE, they change from sending a newline character when enter is pressed to sending a carriage return.  Cowrie can't handle this properly at the login prompt, which prevents the client from being able to login.

I left the old code commented out so it is easier re-enable once Cowrie/Twisted support the Telnet protocol better.

Fixes #414