### PR TITLE
Ignore parentheses in command. Fixed issue #361

### DIFF
--- a/cowrie/core/honeypot.py
+++ b/cowrie/core/honeypot.py
@@ -180,6 +180,14 @@ class HoneyPotShell(object):
             try:
                 tok = self.lexer.get_token()
                 # log.msg( "tok: %s" % (repr(tok)) )
+
+                # Ignore parentheses
+                tok_len = len(tok)
+                tok = tok.strip('(')
+                tok = tok.strip(')')
+                if len(tok) != tok_len and tok == '':
+                    continue
+
                 if tok == self.lexer.eof:
                     if len(tokens):
                         self.cmdpending.append((tokens))


### PR DESCRIPTION
This pull request fixed the parentheses in command issue (#361 ). 

The `shlex` library used by cowrie actually could parse parenthesis correctly. In cowrie's further parsing of a complex command, since the `&&` and `||` were ignored, which means sub-commands' priority was ignored, it's fine to ignore parentheses too. 

Hence after the command being tokenized, this patch will strip all `(` and `)` from both sides of the token. This method is a bit better than regex replacement since a regex will also replace parenthesis in a string parameter. 

I've tested this patch by these cases:

    $ ls; (ps); whoami
    $ ls; ( ps); whoami
    $ ls; ( ps ) ; whoami
    $ ls; (ps ); whoami
    $ ls; ((ps)); whoami
    $ ls;(ps);whoami