### PR TITLE
Fixed IndexError caused by intentionally constructed empty cmdstack

### DIFF
--- a/cowrie/core/honeypot.py
+++ b/cowrie/core/honeypot.py
@@ -112,8 +112,9 @@ class HoneyPotCommand(object):
         """
         try:
             self.protocol.cmdstack.pop()
-            self.protocol.cmdstack[-1].resume()
-        except AttributeError:
+            if len(self.protocol.cmdstack):
+                self.protocol.cmdstack[-1].resume()
+        except (AttributeError, IndexError):
             # Cmdstack could be gone already (wget + disconnect)
             pass
 

--- a/cowrie/core/protocol.py
+++ b/cowrie/core/protocol.py
@@ -353,19 +353,22 @@ class HoneyPotInteractiveProtocol(HoneyPotBaseProtocol, recvline.HistoricRecvLin
     def handle_CTRL_C(self):
         """
         """
-        self.cmdstack[-1].handle_CTRL_C()
+        if len(self.cmdstack):
+            self.cmdstack[-1].handle_CTRL_C()
 
 
     def handle_CTRL_D(self):
         """
         """
-        self.cmdstack[-1].handle_CTRL_D()
+        if len(self.cmdstack):
+            self.cmdstack[-1].handle_CTRL_D()
 
 
     def handle_TAB(self):
         """
         """
-        self.cmdstack[-1].handle_TAB()
+        if len(self.cmdstack):
+            self.cmdstack[-1].handle_TAB()
 
 
     def handle_CTRL_K(self):


### PR DESCRIPTION
From most recent logs, it seems like some scanners will construct certain command sequences to empty `cmdstack` and cause `IndexError` in two places: `honeypot.py` line 115 and `protocol.py` line 361. 

Actually `honeypot.py` line 117 has stated one of these cases. But the `try ... except` there mistakenly cought `AttributeError` other than `IndexError`. 

This patch simply prevent the exception occurring again. 

I'm not quite sure that, after this patch, whether these sessions will be terminated normally. However, it's still better than an unhandled exception. 