### PR TITLE
Fix paths for egrep/fgrep commands

### DIFF
--- a/cowrie/commands/fs.py
+++ b/cowrie/commands/fs.py
@@ -124,9 +124,6 @@ class command_grep(HoneyPotCommand):
 
 
 commands['/bin/grep'] = command_grep
-commands['/usr/bin/grep'] = command_grep
-commands['/usr/bin/egrep'] = command_grep
-commands['/usr/bin/fgrep'] = command_grep
 commands['/bin/egrep'] = command_grep
 commands['/bin/fgrep'] = command_grep
 

--- a/cowrie/commands/fs.py
+++ b/cowrie/commands/fs.py
@@ -127,6 +127,9 @@ commands['/bin/grep'] = command_grep
 commands['/usr/bin/grep'] = command_grep
 commands['/usr/bin/egrep'] = command_grep
 commands['/usr/bin/fgrep'] = command_grep
+commands['grep'] = command_grep
+commands['egrep'] = command_grep
+commands['fgrep'] = command_grep
 
 
 class command_tail(HoneyPotCommand):

--- a/cowrie/commands/fs.py
+++ b/cowrie/commands/fs.py
@@ -127,9 +127,8 @@ commands['/bin/grep'] = command_grep
 commands['/usr/bin/grep'] = command_grep
 commands['/usr/bin/egrep'] = command_grep
 commands['/usr/bin/fgrep'] = command_grep
-commands['grep'] = command_grep
-commands['egrep'] = command_grep
-commands['fgrep'] = command_grep
+commands['/bin/egrep'] = command_grep
+commands['/bin/fgrep'] = command_grep
 
 
 class command_tail(HoneyPotCommand):


### PR DESCRIPTION
Usually /usr/bin is in $PATH, so lets support calling of grep/egrep/fgrep without full path.
```
2017-01-24T03:31:08+0300 [CowrieTelnetTransport,2464,172.95.82.34] CMD: fgrep XDVR /mnt/mtd/dep2.sh
2017-01-24T03:31:08+0300 [CowrieTelnetTransport,2464,172.95.82.34] Command not found: fgrep XDVR /mnt/mtd/dep2.sh

```