### PR TITLE
Append redirection support

### DIFF
--- a/cowrie/commands/curl.py
+++ b/cowrie/commands/curl.py
@@ -93,7 +93,11 @@ class command_curl(HoneyPotCommand):
         self.download_path = cfg.get('honeypot', 'download_path')
 
         if not hasattr(self, 'safeoutfile'):
-            tmp_fname = '%s_%s' % (time.strftime('%Y%m%d%H%M%S'), re.sub('[^A-Za-z0-9]', '_', url))
+            tmp_fname = '%s_%s_%s_%s' % \
+                        (time.strftime('%Y%m%d%H%M%S'),
+                         self.protocol.getProtoTransport().transportId,
+                         self.protocol.terminal.transport.session.id,
+                         re.sub('[^A-Za-z0-9]', '_', url))
             self.safeoutfile = os.path.join(self.download_path, tmp_fname)
 
         self.deferred = self.download(url, outfile, self.safeoutfile)

--- a/cowrie/commands/curl.py
+++ b/cowrie/commands/curl.py
@@ -92,10 +92,10 @@ class command_curl(HoneyPotCommand):
 
         self.download_path = cfg.get('honeypot', 'download_path')
 
-        self.safeoutfile = '%s/%s_%s' % \
-            (self.download_path,
-            time.strftime('%Y%m%d%H%M%S'),
-            re.sub('[^A-Za-z0-9]', '_', url))
+        if not hasattr(self, 'safeoutfile'):
+            tmp_fname = '%s_%s' % (time.strftime('%Y%m%d%H%M%S'), re.sub('[^A-Za-z0-9]', '_', url))
+            self.safeoutfile = os.path.join(self.download_path, tmp_fname)
+
         self.deferred = self.download(url, outfile, self.safeoutfile)
         if self.deferred:
             self.deferred.addCallback(self.success, outfile)
@@ -311,7 +311,7 @@ Options: (H) means HTTP/HTTPS only, (F) means FTP only
             self.exit()
 
         shasum = hashlib.sha256(open(self.safeoutfile, 'rb').read()).hexdigest()
-        hashPath = '%s/%s' % (self.download_path, shasum)
+        hashPath = os.path.join(self.download_path, shasum)
 
         # If we have content already, delete temp file
         if not os.path.exists(hashPath):
@@ -336,7 +336,7 @@ Options: (H) means HTTP/HTTPS only, (F) means FTP only
         os.symlink(shasum, self.safeoutfile)
 
         # FIXME: is this necessary?
-        self.safeoutfile = hashPath
+        # self.safeoutfile = hashPath
 
         # Update the honeyfs to point to downloaded file
         if outfile is not None:

--- a/cowrie/commands/ftpget.py
+++ b/cowrie/commands/ftpget.py
@@ -93,10 +93,13 @@ Download a file via FTP
         cfg = self.protocol.cfg
         url = 'ftp://%s/%s' % (self.host, self.remote_path)
         self.download_path = cfg.get('honeypot', 'download_path')
-        self.safeoutfile = '%s/%s_%s' % \
-                           (self.download_path,
-                            time.strftime('%Y%m%d%H%M%S'),
-                            re.sub('[^A-Za-z0-9]', '_', url))
+
+        tmp_fname = '%s_%s_%s_%s' % \
+                    (time.strftime('%Y%m%d%H%M%S'),
+                     self.protocol.getProtoTransport().transportId,
+                     self.protocol.terminal.transport.session.id,
+                     re.sub('[^A-Za-z0-9]', '_', url))
+        self.safeoutfile = os.path.join(self.download_path, tmp_fname)
 
         result = self.ftp_download(self.safeoutfile)
 
@@ -110,7 +113,7 @@ Download a file via FTP
             return
 
         shasum = hashlib.sha256(open(self.safeoutfile, 'rb').read()).hexdigest()
-        hash_path = '%s/%s' % (self.download_path, shasum)
+        hash_path = os.path.join(self.download_path, shasum)
 
         # If we have content already, delete temp file
         if not os.path.exists(hash_path):

--- a/cowrie/commands/gcc.py
+++ b/cowrie/commands/gcc.py
@@ -4,6 +4,7 @@ import time
 import re
 import getopt
 import random
+import os
 
 from twisted.internet import reactor
 
@@ -164,10 +165,12 @@ gcc version %s (Debian %s-5)""" % (version, version_short, version_short, versio
     def generate_file(self, outfile):
         data = ""
         # TODO: make sure it is written to temp file, not downloads
-        safeoutfile = '%s/%s_%s' % \
-            (self.protocol.cfg.get('honeypot', 'download_path'),
-            time.strftime('%Y%m%d%H%M%S'),
-            re.sub('[^A-Za-z0-9]', '_', outfile))
+        tmp_fname = '%s_%s_%s_%s' % \
+                    (time.strftime('%Y%m%d%H%M%S'),
+                     self.protocol.getProtoTransport().transportId,
+                     self.protocol.terminal.transport.session.id,
+                     re.sub('[^A-Za-z0-9]', '_', outfile))
+        safeoutfile = os.path.join(self.protocol.cfg.get('honeypot', 'download_path'), tmp_fname)
 
         # Data contains random garbage from an actual file, so when
         # catting the file, you'll see some 'real' compiled data

--- a/cowrie/commands/tftp.py
+++ b/cowrie/commands/tftp.py
@@ -56,10 +56,12 @@ class command_tftp(HoneyPotCommand):
 
         self.download_path = cfg.get('honeypot', 'download_path')
 
-        self.safeoutfile = '%s/%s_%s' % \
-                           (self.download_path,
-                            time.strftime('%Y%m%d%H%M%S'),
-                            re.sub('[^A-Za-z0-9]', '_', self.file_to_get))
+        tmp_fname = '%s_%s_%s_%s' % \
+                    (time.strftime('%Y%m%d%H%M%S'),
+                     self.protocol.getProtoTransport().transportId,
+                     self.protocol.terminal.transport.session.id,
+                     re.sub('[^A-Za-z0-9]', '_', self.file_to_get))
+        self.safeoutfile = os.path.join(self.download_path, tmp_fname)
 
         try:
             tclient.download(self.file_to_get, self.safeoutfile, progresshook)

--- a/cowrie/commands/wget.py
+++ b/cowrie/commands/wget.py
@@ -122,7 +122,11 @@ class command_wget(HoneyPotCommand):
         self.download_path = cfg.get('honeypot', 'download_path')
 
         if not hasattr(self, 'safeoutfile'):
-            tmp_fname = '%s_%s' % (time.strftime('%Y%m%d%H%M%S'), re.sub('[^A-Za-z0-9]', '_', url))
+            tmp_fname = '%s_%s_%s_%s' % \
+                        (time.strftime('%Y%m%d%H%M%S'),
+                         self.protocol.getProtoTransport().transportId,
+                         self.protocol.terminal.transport.session.id,
+                         re.sub('[^A-Za-z0-9]', '_', url))
             self.safeoutfile = os.path.join(self.download_path, tmp_fname)
 
         self.deferred = self.download(url, outfile, self.safeoutfile)

--- a/cowrie/commands/wget.py
+++ b/cowrie/commands/wget.py
@@ -121,7 +121,7 @@ class command_wget(HoneyPotCommand):
 
         self.download_path = cfg.get('honeypot', 'download_path')
 
-        if not self.safeoutfile:
+        if not hasattr(self, 'safeoutfile'):
             tmp_fname = '%s_%s' % (time.strftime('%Y%m%d%H%M%S'), re.sub('[^A-Za-z0-9]', '_', url))
             self.safeoutfile = os.path.join(self.download_path, tmp_fname)
 

--- a/cowrie/commands/wget.py
+++ b/cowrie/commands/wget.py
@@ -121,10 +121,10 @@ class command_wget(HoneyPotCommand):
 
         self.download_path = cfg.get('honeypot', 'download_path')
 
-        self.safeoutfile = '%s/%s_%s' % \
-            (self.download_path,
-            time.strftime('%Y%m%d%H%M%S'),
-            re.sub('[^A-Za-z0-9]', '_', url))
+        if not self.safeoutfile:
+            tmp_fname = '%s_%s' % (time.strftime('%Y%m%d%H%M%S'), re.sub('[^A-Za-z0-9]', '_', url))
+            self.safeoutfile = os.path.join(self.download_path, tmp_fname)
+
         self.deferred = self.download(url, outfile, self.safeoutfile)
         if self.deferred:
             self.deferred.addCallback(self.success, outfile)
@@ -185,8 +185,9 @@ class command_wget(HoneyPotCommand):
             log.msg("there's no file " + self.safeoutfile)
             self.exit()
 
-        shasum = hashlib.sha256(open(self.safeoutfile, 'rb').read()).hexdigest()
-        hash_path = '%s/%s' % (self.download_path, shasum)
+        with open(self.safeoutfile, 'rb') as f:
+            shasum = hashlib.sha256(f.read()).hexdigest()
+        hash_path = os.path.join(self.download_path, shasum)
 
         # If we have content already, delete temp file
         if not os.path.exists(hash_path):
@@ -208,10 +209,10 @@ class command_wget(HoneyPotCommand):
                 shasum=shasum)
 
         # Link friendly name to hash
-        os.symlink( shasum, self.safeoutfile )
+        os.symlink(shasum, self.safeoutfile)
 
         # FIXME: is this necessary?
-        self.safeoutfile = hash_path
+        # self.safeoutfile = hash_path
 
         # Update the honeyfs to point to downloaded file
         f = self.fs.getfile(outfile)

--- a/cowrie/core/honeypot.py
+++ b/cowrie/core/honeypot.py
@@ -42,7 +42,7 @@ class HoneyPotCommand(object):
                 index = self.args.index('>')
                 b_append = False
             self.outfile = self.fs.resolve_path(str(self.args[(index + 1)]), self.protocol.cwd)
-            del self.args[index:index+1]
+            del self.args[index:]
             p = self.fs.getfile(self.outfile)
             if not p or not p[fs.A_REALFILE] or p[fs.A_REALFILE].startswith('honeyfs') or not b_append:
                 self.safeoutfile = '%s/%s-%s-%s-redir_%s' % (

--- a/cowrie/core/honeypot.py
+++ b/cowrie/core/honeypot.py
@@ -45,12 +45,12 @@ class HoneyPotCommand(object):
             del self.args[index:]
             p = self.fs.getfile(self.outfile)
             if not p or not p[fs.A_REALFILE] or p[fs.A_REALFILE].startswith('honeyfs') or not b_append:
-                self.safeoutfile = '%s/%s-%s-%s-redir_%s' % (
-                    self.protocol.cfg.get('honeypot', 'download_path'),
-                    time.strftime('%Y%m%d-%H%M%S'),
-                    self.protocol.getProtoTransport().transportId,
-                    self.protocol.terminal.transport.session.id,
-                    re.sub('[^A-Za-z0-9]', '_', self.outfile))
+                tmp_fname = '%s-%s-%s-redir_%s' % \
+                            (time.strftime('%Y%m%d-%H%M%S'),
+                             self.protocol.getProtoTransport().transportId,
+                             self.protocol.terminal.transport.session.id,
+                             re.sub('[^A-Za-z0-9]', '_', self.outfile))
+                self.safeoutfile = os.path.join(self.protocol.cfg.get('honeypot', 'download_path'), tmp_fname)
                 perm = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
                 try:
                     self.fs.mkfile(self.outfile, 0, 0, 0, stat.S_IFREG | perm)

--- a/cowrie/core/honeypot.py
+++ b/cowrie/core/honeypot.py
@@ -42,7 +42,7 @@ class HoneyPotCommand(object):
                 index = self.args.index('>')
                 b_append = False
             self.outfile = self.fs.resolve_path(str(self.args[(index + 1)]), self.protocol.cwd)
-            del self.args[index:]
+            del self.args[index:index+1]
             p = self.fs.getfile(self.outfile)
             if not p or not p[fs.A_REALFILE] or p[fs.A_REALFILE].startswith('honeyfs') or not b_append:
                 self.safeoutfile = '%s/%s-%s-%s-redir_%s' % (

--- a/cowrie/core/honeypot.py
+++ b/cowrie/core/honeypot.py
@@ -32,31 +32,40 @@ class HoneyPotCommand(object):
         self.errorWrite = self.protocol.pp.errReceived
         # MS-DOS style redirect handling, inside the command
         # TODO: handle >>, 2>, etc
-        if '>' in self.args:
+        if '>' in self.args or '>>' in self.args:
             self.writtenBytes = 0
             self.write = self.write_to_file
-            index = self.args.index(">")
+            if '>>' in self.args:
+                index = self.args.index('>>')
+                b_append = True
+            else:
+                index = self.args.index('>')
+                b_append = False
             self.outfile = self.fs.resolve_path(str(self.args[(index + 1)]), self.protocol.cwd)
             del self.args[index:]
-            self.safeoutfile = '%s/%s-%s-%s-redir_%s' % (
-                self.protocol.cfg.get('honeypot', 'download_path'),
-                time.strftime('%Y%m%d-%H%M%S'),
-                self.protocol.getProtoTransport().transportId,
-                self.protocol.terminal.transport.session.id,
-                re.sub('[^A-Za-z0-9]', '_', self.outfile))
-            perm = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
-            try:
-                self.fs.mkfile(self.outfile, 0, 0, 0, stat.S_IFREG | perm)
-            except fs.FileNotFound:
-                # The outfile locates at a non-existing directory.
-                self.protocol.pp.outReceived('-bash: %s: No such file or directory\n' % self.outfile)
-                self.write = self.write_to_failed
-                self.outfile = None
-                self.safeoutfile = None
+            p = self.fs.getfile(self.outfile)
+            if not p or not p[fs.A_REALFILE] or p[fs.A_REALFILE].startswith('honeyfs') or not b_append:
+                self.safeoutfile = '%s/%s-%s-%s-redir_%s' % (
+                    self.protocol.cfg.get('honeypot', 'download_path'),
+                    time.strftime('%Y%m%d-%H%M%S'),
+                    self.protocol.getProtoTransport().transportId,
+                    self.protocol.terminal.transport.session.id,
+                    re.sub('[^A-Za-z0-9]', '_', self.outfile))
+                perm = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
+                try:
+                    self.fs.mkfile(self.outfile, 0, 0, 0, stat.S_IFREG | perm)
+                except fs.FileNotFound:
+                    # The outfile locates at a non-existing directory.
+                    self.protocol.pp.outReceived('-bash: %s: No such file or directory\n' % self.outfile)
+                    self.write = self.write_to_failed
+                    self.outfile = None
+                    self.safeoutfile = None
 
+                else:
+                    with open(self.safeoutfile, 'a'):
+                        self.fs.update_realfile(self.fs.getfile(self.outfile), self.safeoutfile)
             else:
-                with open(self.safeoutfile, 'a'):
-                    self.fs.update_realfile(self.fs.getfile(self.outfile), self.safeoutfile)
+                self.safeoutfile = p[fs.A_REALFILE]
 
 
     def check_arguments(self, application, args):

--- a/cowrie/core/protocol.py
+++ b/cowrie/core/protocol.py
@@ -196,7 +196,8 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         self.cmdstack.append(obj)
         obj.start()
         if hasattr(obj, 'safeoutfile'):
-            self.terminal.redirFiles.add(obj.safeoutfile)
+            if obj.safeoutfile:
+                self.terminal.redirFiles.add(obj.safeoutfile)
         if self.pp:
             self.pp.outConnectionLost()
 

--- a/cowrie/core/protocol.py
+++ b/cowrie/core/protocol.py
@@ -195,6 +195,8 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         obj.set_input_data(pp.input_data)
         self.cmdstack.append(obj)
         obj.start()
+        if hasattr(obj, 'safeoutfile'):
+            self.terminal.redirFiles.add(obj.safeoutfile)
         if self.pp:
             self.pp.outConnectionLost()
 

--- a/cowrie/insults/insults.py
+++ b/cowrie/insults/insults.py
@@ -143,7 +143,7 @@ class LoggingServerProtocol(insults.ServerProtocol):
                         os.rename(self.stdinlogFile, shasumfile)
                     os.symlink(shasum, self.stdinlogFile)
                 log.msg(eventid='cowrie.session.file_download',
-                        format='Saved stdin contents to %(outfile)s',
+                        format='Saved stdin contents with SHA-256 %(shasum)s to %(outfile)s',
                         url='stdin',
                         outfile=shasumfile,
                         shasum=shasum)
@@ -170,7 +170,7 @@ class LoggingServerProtocol(insults.ServerProtocol):
                         os.rename(f, shasumfile)
                     os.symlink(shasum, f)
                     log.msg(eventid='cowrie.session.file_download',
-                            format='Saved redir contents to %(outfile)s',
+                            format='Saved redir contents with SHA-256 %(shasum)s to %(outfile)s',
                             url='redir',
                             outfile=shasumfile,
                             shasum=shasum)


### PR DESCRIPTION
This pull request solves the following problems:

1) Adds support for append redirection (">>")
2) Adds hashing for redir files
3) Removes empty redir files on connection lost event
4) Fixes bug in wget command, when it was overwriting safeoutfile name  if used in command like (`wget url -O - > some_file`)
5) Fixes path combining in wget command (os.path.join instead of "%s/%s" string formatting.
6) Insufficient count of parameters in forming "safeoutfile" file name could cause a race condition between two simultaneously running wget/curl/ftpget/tftp commands. The pull request forces usage of transportID and sessionID in all "safeoutfile" file names.