### PR TITLE
Prevent cowrie from crashing on invalid host for wget

### DIFF
--- a/cowrie/commands/wget.py
+++ b/cowrie/commands/wget.py
@@ -142,6 +142,9 @@ class command_wget(HoneyPotCommand):
             path = parsed.path or '/'
             if scheme != 'http' and scheme != 'https':
                 raise NotImplementedError
+            if not host:
+                self.exit()
+                return None
         except:
             self.write('%s: Unsupported scheme.\n' % (url,))
             self.exit()


### PR DESCRIPTION
An error in the Hajime trojan caused cowrie to crash, when it sent us a malformed wget command:

2017-01-24T18:32:40+0300 [CowrieTelnetTransport,158,attackers_ip] Command found: wget http:// < invalid address > /.i
2017-01-24T18:32:40+0300 [CowrieTelnetTransport,158,attackers_ip] Unhandled Error
        Traceback (most recent call last):
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/python/log.py", line 103, in callWithLogger
            return callWithContext({"system": lp}, func, *args, **kw)
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/python/log.py", line 86, in callWithContext
            return context.call({ILogContext: newCtx}, func, *args, **kw)
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/python/context.py", line 118, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/python/context.py", line 81, in callWithContext
            return func(*args,**kw)
        --- <exception caught here> ---
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/internet/posixbase.py", line 597, in _doReadOrWrite
            why = selectable.doRead()
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/internet/tcp.py", line 208, in doRead
            return self._dataReceived(data)
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/internet/tcp.py", line 214, in _dataReceived
            rval = self.protocol.dataReceived(data)
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/conch/telnet.py", line 636, in dataReceived
            self.applicationDataReceived(b''.join(appDataBuffer))
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/conch/telnet.py", line 988, in applicationDataReceived
            self.protocol.dataReceived(data)
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/conch/telnet.py", line 1035, in dataReceived
            self.protocol.dataReceived(data)
          File "/home/cowrie/cowrie_armel/cowrie/insults/insults.py", line 113, in dataReceived
            insults.ServerProtocol.dataReceived(self, data)
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/conch/insults/insults.py", line 537, in dataReceived
            self.terminalProtocol.keystrokeReceived(ch, None)
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/conch/recvline.py", line 220, in keystrokeReceived
            m()
          File "/home/cowrie/cowrie_armel/cowrie/core/protocol.py", line 357, in handle_RETURN
            return recvline.RecvLine.handle_RETURN(self)
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/conch/recvline.py", line 287, in handle_RETURN
            self.lineReceived(line)
          File "/home/cowrie/cowrie_armel/cowrie/core/protocol.py", line 187, in lineReceived
            self.cmdstack[-1].lineReceived(line)
          File "/home/cowrie/cowrie_armel/cowrie/core/honeypot.py", line 246, in lineReceived
            self.runCommand()
          File "/home/cowrie/cowrie_armel/cowrie/core/honeypot.py", line 353, in runCommand
            self.protocol.call_command(pp, cmdclass, *cmd_array[0]['rargs'])
          File "/home/cowrie/cowrie_armel/cowrie/core/protocol.py", line 334, in call_command
            HoneyPotBaseProtocol.call_command(self, pp, cmd, *args)
          File "/home/cowrie/cowrie_armel/cowrie/core/protocol.py", line 197, in call_command
            obj.start()
          File "/home/cowrie/cowrie_armel/cowrie/core/honeypot.py", line 109, in start
            self.exit()
          File "/home/cowrie/cowrie_armel/cowrie/core/honeypot.py", line 125, in exit
            self.protocol.cmdstack[-1].resume()
          File "/home/cowrie/cowrie_armel/cowrie/core/honeypot.py", line 361, in resume
            self.runCommand()
          File "/home/cowrie/cowrie_armel/cowrie/core/honeypot.py", line 353, in runCommand
            self.protocol.call_command(pp, cmdclass, *cmd_array[0]['rargs'])
          File "/home/cowrie/cowrie_armel/cowrie/core/protocol.py", line 334, in call_command
            HoneyPotBaseProtocol.call_command(self, pp, cmd, *args)
          File "/home/cowrie/cowrie_armel/cowrie/core/protocol.py", line 197, in call_command
            obj.start()
          File "/home/cowrie/cowrie_armel/cowrie/commands/wget.py", line 128, in start
            self.deferred = self.download(url, outfile, self.safeoutfile)
          File "/home/cowrie/cowrie_armel/cowrie/commands/wget.py", line 169, in download
            host, port, factory, bindAddress=out_addr)
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/internet/posixbase.py", line 482, in connectTCP
            c = tcp.Connector(host, port, factory, timeout, bindAddress, self)
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/internet/tcp.py", line 1164, in __init__
            if abstract.isIPv6Address(host):
          File "/home/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/internet/abstract.py", line 522, in isIPv6Address
            if '%' in addr:
        exceptions.TypeError: argument of type 'NoneType' is not iterable

