### PR TITLE
Remove empty tftp files, double logging fix

### DIFF
--- a/cowrie/commands/tftp.py
+++ b/cowrie/commands/tftp.py
@@ -101,6 +101,9 @@ class command_tftp(HoneyPotCommand):
                     f[A_REALFILE] = hash_path
 
         except tftpy.TftpException, err:
+            if os.path.exists(self.safeoutfile):
+                if os.path.getsize(self.safeoutfile) == 0:
+                    os.remove(self.safeoutfile)
             return
 
         except KeyboardInterrupt:

--- a/cowrie/commands/tftp.py
+++ b/cowrie/commands/tftp.py
@@ -56,7 +56,11 @@ class command_tftp(HoneyPotCommand):
 
         self.download_path = cfg.get('honeypot', 'download_path')
 
-        tmp_fname = '%s_%s' % (time.strftime('%Y%m%d%H%M%S'), re.sub('[^A-Za-z0-9]', '_', self.file_to_get))
+        tmp_fname = '%s_%s_%s_%s' % \
+                    (time.strftime('%Y%m%d%H%M%S'),
+                     self.protocol.getProtoTransport().transportId,
+                     self.protocol.terminal.transport.session.id,
+                     re.sub('[^A-Za-z0-9]', '_', self.file_to_get))
         self.safeoutfile = os.path.join(self.download_path, tmp_fname)
 
         try:
@@ -90,8 +94,6 @@ class command_tftp(HoneyPotCommand):
                             shasum=shasum)
 
                     # Link friendly name to hash
-                    os.symlink(shasum, self.safeoutfile)
-
                     os.symlink(shasum, self.safeoutfile)
 
                     # Update the honeyfs to point to downloaded file


### PR DESCRIPTION
After reviewing command_tftp code, I've found two issues:

1) It lacks any checks for file size, so we could end up with reporting zero-sized files
2) It logs tftp download twice