### PR TITLE
Logstash sample config fix

### DIFF
--- a/doc/elk/README.md
+++ b/doc/elk/README.md
@@ -62,7 +62,6 @@ chown kibana:kibana /var/log/kibana
 
 ```
 wget http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz
-wget http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.mmdb.gz
 ```
 
 * Place these somewhere in your filesystem and make sure that "logstash" user can read it
@@ -150,4 +149,4 @@ http://<hostname>:9200/_search?q=cowrie&size=5
 
 * Refer to elastic's documentation about proper configuration of the system for the best elasticsearch's performance
 
-* You may avoid installing nginx for restricting access to the kibana by installing official elastic's plugin called "XPack" (https://www.elastic.co/products/x-pack) 
+* You may avoid installing nginx for restricting access to the kibana by installing official elastic's plugin called "X-Pack" (https://www.elastic.co/products/x-pack) 

--- a/doc/elk/logstash-cowrie.conf
+++ b/doc/elk/logstash-cowrie.conf
@@ -34,12 +34,6 @@ filter {
                 source => "src_ip"
                 target => "geoip"
                 database => "/opt/logstash/vendor/geoip/GeoLite2-City.dat"
-                add_field => [ "[geoip][coordinates]", "%{[geoip][longitude]}" ]
-                add_field => [ "[geoip][coordinates]", "%{[geoip][latitude]}"  ]
-            }
-
-            mutate {
-                convert => [ "[geoip][coordinates]", "float" ]
             }
         }
     }


### PR DESCRIPTION
This patch removes redundant field [geoip][coordinates], because logstash's geoip filter adds [geoip][location] field that contains exactly the same info.
Also, I've removed the second geoip base from README.md. because it's not needed in modern MAXMIND geoip databases. All necessary information is included in City db.