### PR TITLE
Force generation of new safeoutfile, if the one we have is sha256 hash

### DIFF
--- a/cowrie/commands/curl.py
+++ b/cowrie/commands/curl.py
@@ -92,7 +92,7 @@ class command_curl(HoneyPotCommand):
 
         self.download_path = cfg.get('honeypot', 'download_path')
 
-        if not hasattr(self, 'safeoutfile'):
+        if not hasattr(self, 'safeoutfile') or re.match('[a-fA-F0-9]{64}', self.safeoutfile):
             tmp_fname = '%s_%s_%s_%s' % \
                         (time.strftime('%Y%m%d%H%M%S'),
                          self.protocol.getProtoTransport().transportId,

--- a/cowrie/commands/wget.py
+++ b/cowrie/commands/wget.py
@@ -121,7 +121,7 @@ class command_wget(HoneyPotCommand):
 
         self.download_path = cfg.get('honeypot', 'download_path')
 
-        if not hasattr(self, 'safeoutfile'):
+        if not hasattr(self, 'safeoutfile') or re.match('[a-fA-F0-9]{64}', self.safeoutfile):
             tmp_fname = '%s_%s_%s_%s' % \
                         (time.strftime('%Y%m%d%H%M%S'),
                          self.protocol.getProtoTransport().transportId,


### PR DESCRIPTION
I've noticed that in some attack sessions wget was using safeoutfile that is SHA256 hash of previously saved file. That resulted in replacing of the file pointed by safeoutfile with symlink to newly downloaded file.

Commit forces generating of new safeoutfile in wget/curl if the specified safeoutfile is SHA256 hash.