### PR TITLE
Report full url instead of just file name in tftp file_download event

### DIFF
--- a/cowrie/commands/tftp.py
+++ b/cowrie/commands/tftp.py
@@ -87,9 +87,11 @@ class command_tftp(HoneyPotCommand):
                         os.remove(self.safeoutfile)
                         log.msg("Not storing duplicate content " + shasum)
 
+                    url = 'tftp://%s/%s' % (self.hostname, self.file_to_get.strip('/'))
+
                     log.msg(eventid='cowrie.session.file_download',
                             format='Downloaded tftpFile (%(url)s) with SHA-256 %(shasum)s to %(outfile)s',
-                            url=self.file_to_get,
+                            url=url,
                             outfile=hash_path,
                             shasum=shasum)
 


### PR DESCRIPTION
At this moment tftp command report file_download event as following:
>Downloaded tftpFile (/tftp2.sh) with SHA-256 f210336b4999d80afdc1a25be407d72f55a57931022f3c3ee5e428859dcdd0dd to dl/f210336b4999d80afdc1a25be407d72f55a57931022f3c3ee5e428859dcdd0dd

The commit adds hostname to the url, so it would be:

>Downloaded tftpFile (tftp://somehost/tftp2.sh) with SHA-256 f210336b4999d80afdc1a25be407d72f55a57931022f3c3ee5e428859dcdd0dd to dl/f210336b4999d80afdc1a25be407d72f55a57931022f3c3ee5e428859dcdd0dd

If you are about to merge #439, then just ignore it, else I think it would be useful.