### PR TITLE
Log standardization of the commands wget/curl/ftpget/tftp.

### DIFF
--- a/cowrie/commands/curl.py
+++ b/cowrie/commands/curl.py
@@ -314,8 +314,9 @@ Options: (H) means HTTP/HTTPS only, (F) means FTP only
             log.msg("there's no file " + self.safeoutfile)
             self.exit()
 
-        shasum = hashlib.sha256(open(self.safeoutfile, 'rb').read()).hexdigest()
-        hashPath = os.path.join(self.download_path, shasum)
+        with open(self.safeoutfile, 'rb') as f:
+            shasum = hashlib.sha256(f.read()).hexdigest()
+            hashPath = os.path.join(self.download_path, shasum)
 
         # If we have content already, delete temp file
         if not os.path.exists(hashPath):
@@ -323,12 +324,6 @@ Options: (H) means HTTP/HTTPS only, (F) means FTP only
         else:
             os.remove(self.safeoutfile)
             log.msg("Not storing duplicate content " + shasum)
-
-        self.protocol.logDispatch(eventid='cowrie.session.file_download',
-                                  format='Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s',
-                                  url=self.url,
-                                  outfile=hashPath,
-                                  shasum=shasum)
 
         log.msg(eventid='cowrie.session.file_download',
                 format='Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s',
@@ -343,9 +338,7 @@ Options: (H) means HTTP/HTTPS only, (F) means FTP only
         # self.safeoutfile = hashPath
 
         # Update the honeyfs to point to downloaded file
-        if outfile is not None:
-            f = self.fs.getfile(outfile)
-            f[A_REALFILE] = hashPath
+        self.fs.update_realfile(self.fs.getfile(outfile), hashPath)
         self.exit()
 
 

--- a/cowrie/commands/curl.py
+++ b/cowrie/commands/curl.py
@@ -325,6 +325,12 @@ Options: (H) means HTTP/HTTPS only, (F) means FTP only
             os.remove(self.safeoutfile)
             log.msg("Not storing duplicate content " + shasum)
 
+        self.protocol.logDispatch(eventid='cowrie.session.file_download',
+                                  format='Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s',
+                                  url=self.url,
+                                  outfile=hashPath,
+                                  shasum=shasum)
+
         log.msg(eventid='cowrie.session.file_download',
                 format='Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s',
                 url=self.url,

--- a/cowrie/commands/tftp.py
+++ b/cowrie/commands/tftp.py
@@ -103,11 +103,11 @@ class command_tftp(HoneyPotCommand):
             # Link friendly name to hash
             os.symlink(shasum, self.safeoutfile)
 
+            self.safeoutfile = None
+
             # Update the honeyfs to point to downloaded file
-            f = self.fs.getfile(self.file_to_get)
-            f[A_REALFILE] = hash_path
-
-
+            self.fs.update_realfile(self.fs.getfile(self.file_to_get), hash_path)
+            self.exit()
 
 
     def start(self):

--- a/cowrie/commands/wget.py
+++ b/cowrie/commands/wget.py
@@ -203,6 +203,12 @@ class command_wget(HoneyPotCommand):
             os.remove(self.safeoutfile)
             log.msg("Not storing duplicate content " + shasum)
 
+        self.protocol.logDispatch(eventid='cowrie.session.file_download',
+                                  format='Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s',
+                                  url=self.url,
+                                  outfile=hash_path,
+                                  shasum=shasum)
+
         log.msg(eventid='cowrie.session.file_download',
                 format='Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s',
                 url=self.url,

--- a/cowrie/commands/wget.py
+++ b/cowrie/commands/wget.py
@@ -194,7 +194,7 @@ class command_wget(HoneyPotCommand):
 
         with open(self.safeoutfile, 'rb') as f:
             shasum = hashlib.sha256(f.read()).hexdigest()
-        hash_path = os.path.join(self.download_path, shasum)
+            hash_path = os.path.join(self.download_path, shasum)
 
         # If we have content already, delete temp file
         if not os.path.exists(hash_path):
@@ -202,12 +202,6 @@ class command_wget(HoneyPotCommand):
         else:
             os.remove(self.safeoutfile)
             log.msg("Not storing duplicate content " + shasum)
-
-        self.protocol.logDispatch(eventid='cowrie.session.file_download',
-            format='Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s',
-            url=self.url,
-            outfile=hash_path,
-            shasum=shasum )
 
         log.msg(eventid='cowrie.session.file_download',
                 format='Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s',
@@ -218,12 +212,10 @@ class command_wget(HoneyPotCommand):
         # Link friendly name to hash
         os.symlink(shasum, self.safeoutfile)
 
-        # FIXME: is this necessary?
-        # self.safeoutfile = hash_path
+        self.safeoutfile = None
 
         # Update the honeyfs to point to downloaded file
-        f = self.fs.getfile(outfile)
-        f[A_REALFILE] = hash_path
+        self.fs.update_realfile(self.fs.getfile(outfile), hash_path)
         self.exit()
 
 


### PR DESCRIPTION
All listed commands in case of success do the same - hash file, move it to dl, update real file. But they all do it in a slightly different way.

Also I've removed a double logging from curl/wget commands.