### PR TITLE
Missing import

### DIFF
--- a/cowrie/commands/scp.py
+++ b/cowrie/commands/scp.py
@@ -28,6 +28,7 @@
 
 import getopt
 
+from twisted.python import log
 from cowrie.core.honeypot import HoneyPotCommand
 
 commands = {}


### PR DESCRIPTION
Without 'from twisted.python import log' scp is generating error within cowrie session

2017-02-16 13:16:24+0100 [SSHChannel session (0) on SSHService ssh-connection on HoneyPotSSHTransport,8,10.29.196.220] Unhandled Error
        Traceback (most recent call last):
          File "/local/miodolapki/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/python/context.py", line 118, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/local/miodolapki/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/python/context.py", line 81, in callWithContext
            return func(*args,**kw)
          File "/local/miodolapki/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/conch/ssh/service.py", line 44, in packetReceived
            return f(packet)
          File "/local/miodolapki/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/conch/ssh/connection.py", line 242, in ssh_CHANNEL_DATA
            log.callWithLogger(channel, channel.dataReceived, data)
        --- <exception caught here> ---
          File "/local/miodolapki/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/python/log.py", line 101, in callWithLogger
            return callWithContext({"system": lp}, func, *args, **kw)
          File "/local/miodolapki/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/python/log.py", line 84, in callWithContext
            return context.call({ILogContext: newCtx}, func, *args, **kw)
          File "/local/miodolapki/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/python/context.py", line 118, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/local/miodolapki/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/python/context.py", line 81, in callWithContext
            return func(*args,**kw)
          File "/local/miodolapki/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/conch/ssh/session.py", line 109, in dataReceived
            self.client.transport.write(data)
          File "/local/miodolapki/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/conch/ssh/session.py", line 160, in write
            self.proto.dataReceived(data)
          File "/local/miodolapki/cowrie/cowrie/insults/insults.py", line 112, in dataReceived
            insults.ServerProtocol.dataReceived(self, data)
          File "/local/miodolapki/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/conch/insults/insults.py", line 435, in dataReceived
            self.terminalProtocol.keystrokeReceived(ch, None)
          File "/local/miodolapki/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/conch/recvline.py", line 201, in keystrokeReceived
            m()
          File "/local/miodolapki/cowrie/cowrie/core/protocol.py", line 353, in handle_RETURN
            return recvline.RecvLine.handle_RETURN(self)
          File "/local/miodolapki/cowrie/cowrie-env/lib/python2.7/site-packages/twisted/conch/recvline.py", line 259, in handle_RETURN
            self.lineReceived(line)
          File "/local/miodolapki/cowrie/cowrie/core/protocol.py", line 187, in lineReceived
            self.cmdstack[-1].lineReceived(line)
          File "/local/miodolapki/cowrie/cowrie/commands/scp.py", line 72, in lineReceived
            log.msg(eventid='cowrie.session.file_download',
        exceptions.NameError: global name 'log' is not defined