### PR TITLE
Removed duplicates from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,3 @@ service_identity
 pycrypto
 python-dateutil
 tftpy
-packaging
-appdirs


### PR DESCRIPTION
I got errors related to duplicates in `requirements.txt` during install cowrie on Debian wheezy.