### PR TITLE
fix double requirement given

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,3 @@ service_identity
 pycrypto
 python-dateutil
 tftpy
-packaging
-appdirs


### PR DESCRIPTION
Double requirement given: packaging (from -r requirements.txt (line 15)) (already in packaging (from -r requirements.txt (line 7)), name='packaging')