### PR TITLE
Use ${PIDFILE} instead of cowrie.pid when using authbind

### DIFF
--- a/bin/cowrie
+++ b/bin/cowrie
@@ -48,7 +48,7 @@ cowrie_start() {
     then
         twistd $XARGS -l log/cowrie.log --umask 0077 --pidfile ${PIDFILE} cowrie
     else
-        authbind --deep twistd $XARGS -l log/cowrie.log --umask 0077 --pidfile cowrie.pid cowrie
+        authbind --deep twistd $XARGS -l log/cowrie.log --umask 0077 --pidfile ${PIDFILE} cowrie
     fi
 }
 


### PR DESCRIPTION
Fixes #477

When authbind is enabled, the command to run cowrie was using a hard-coded value for the pid file instead of the variable used everywhere else.