### PR TITLE
Fix a bug in a portable relative paths resolver

### DIFF
--- a/bin/cowrie
+++ b/bin/cowrie
@@ -15,7 +15,7 @@ find_cowrie_directory() {
     else
         COWRIEDIR=$(dirname $PWD/$0)/..
     fi
-    COWRIEDIR=$(cd ${COWRIEDIR} && pwd -P 2>/dev/null | pwd)
+    COWRIEDIR=$(cd ${COWRIEDIR} && pwd -P 2>/dev/null || pwd)
 }
 
 activate_venv() {


### PR DESCRIPTION
It turns out that this `|` was a typo. (See https://unix.stackexchange.com/questions/24293/converting-relative-path-to-absolute-path/24342?noredirect=1#comment623203_24342)