### PR TITLE
Update cowrie - conditional virtual environment toggle

### DIFF
--- a/bin/cowrie
+++ b/bin/cowrie
@@ -1,5 +1,10 @@
 #!/bin/bash
+#Change the below to yes if you are using authbind to listen to port 22
 AUTHBIND_ENABLED=no
+
+#Change the below to yes to activate the "cowrie-env" virtual environment
+VIRTUALENV_ENABLED=yes
+
 #Change the below to -n to disable daemonizing (for instance when using supervisor)
 DAEMONIZE=""
 
@@ -42,7 +47,10 @@ cowrie_status() {
 
 cowrie_start() {
     # Start Cowrie
-    activate_venv "cowrie-env"
+    if [ $VIRTUALENV_ENABLED = "yes" ]
+    then
+        activate_venv "cowrie-env"
+    fi
     echo "Starting cowrie with extra arguments [$XARGS $DAEMONIZE] ..."
     if [ $AUTHBIND_ENABLED = "no" ]
     then


### PR DESCRIPTION
Calling by default activate_venv forces the use of virtual environments on everyone.
If one does not use virtual environments, the systemd service script will fail giving a reason that has nothing to do with this.

I have noticed this problem when i have replaced the systemd service script to deprecate the use of start/stop scripts.

The use of a conditional statements solves this for me.

While investigating this issue, I have also noticed the folllwing:

1-there are two pid files declared:
PIDFILE in cowrie
PIDFile in service.cowrie

2-if you run "bin/cowrie start" as the cowrie user and then you run "service cowrie stop" as root, the execstop command will not be run (this could be the normal behaviour of systemd though).

To minimise future issues issues, the pidfile, authbind and virtualenv variables could be passed as parameters from the systemd service script and defined conditionally within "cowrie" if they are missing..