### PR TITLE
Use twisted endpoints for listening on ports/addresses

### DIFF
--- a/cowrie.cfg.dist
+++ b/cowrie.cfg.dist
@@ -230,6 +230,17 @@ version = SSH-2.0-OpenSSH_6.0p1 Debian-4+deb7u2
 #listen_port = 2222
 
 
+# Endpoint to listen on for incoming SSH connections.
+# Specify this instead of listen_addr/listen_port
+# See https://twistedmatrix.com/documents/current/core/howto/endpoints.html#servers
+# (default: converts listen_addr/listen_port settings into endpoints)
+
+# (use tcp: endpoints to listen on ports and interfaces)
+# listen_endpoints = tcp:2222:interface=0.0.0.0 tcp:8888:interface=0.0.0.0
+
+# (use systemd: endpoint to use systemd activation)
+# listend_endpoints = systemd:domain=INET:index=0
+
 # sftp_enabled enables the sftp subsystem
 sftp_enabled = true
 
@@ -280,6 +291,17 @@ enabled = false
 #
 # (default: 2223)
 #listen_port = 2223
+
+# Endpoint to listen on for incoming Telnet connections.
+# Specify this instead of listen_addr/listen_port
+# See https://twistedmatrix.com/documents/current/core/howto/endpoints.html#servers
+# (default: converts listen_addr/listen_port settings into endpoints)
+
+# (use tcp: endpoints to listen on ports and interfaces)
+# listen_endpoints = tcp:2223:interface=0.0.0.0 tcp:8888:interface=0.0.0.0
+
+# (use systemd: endpoint to use systemd activation)
+# listend_endpoints = systemd:domain=INET:index=0
 
 # Source Port to report in logs (useful if you use iptables to forward ports to Cowrie)
 #reported_port = 23

--- a/cowrie/core/utils.py
+++ b/cowrie/core/utils.py
@@ -6,6 +6,10 @@
 This module contains ...
 """
 
+from twisted.application import internet
+from twisted.internet import endpoints, reactor
+
+
 def durationHuman(seconds):
     """
     Turn number of seconds into human readable string
@@ -89,3 +93,31 @@ def uptime(total_seconds):
         s += '{} min'.format(str(minutes))
     return s
 
+
+def get_endpoints_from_section(cfg, section, default_port):
+    if cfg.has_option(section, 'listen_endpoints'):
+        return cfg.get(section, 'listen_endpoints').split()
+
+    if cfg.has_option(section, 'listen_addr'):
+        listen_addr = cfg.get(section, 'listen_addr')
+    else:
+        listen_addr = '0.0.0.0'
+
+    if cfg.has_option(section, 'listen_port'):
+        listen_port = cfg.getint(section, 'listen_port')
+    else:
+        listen_port = default_port
+
+    listen_endpoints = []
+    for i in listen_addr.split():
+        listen_endpoints.append('tcp:{}:interface={}'.format(listen_port, i))
+
+    return listen_endpoints
+
+
+def create_endpoint_services(reactor, parent, listen_endpoints, factory):
+    for listen_endpoint in listen_endpoints:
+        endpoint = endpoints.serverFromString(reactor, listen_endpoint.encode('utf-8'))
+        service = internet.StreamServerEndpointService(endpoint, factory)
+        # FIXME: Use addService on parent ?
+        service.setServiceParent(parent)

--- a/cowrie/test/test_utils.py
+++ b/cowrie/test/test_utils.py
@@ -1,7 +1,18 @@
+import ConfigParser
+import io
+import textwrap
 
+from twisted.application.service import MultiService
+from twisted.internet import protocol, reactor
 from twisted.trial import unittest
 
-from cowrie.core.utils import durationHuman
+from cowrie.core.utils import durationHuman, get_endpoints_from_section, create_endpoint_services
+
+
+def get_config(config_string):
+    config = ConfigParser.RawConfigParser()
+    config.readfp(io.BytesIO(textwrap.dedent(config_string)))
+    return config
 
 
 class UtilsTestCase(unittest.TestCase):
@@ -20,3 +31,47 @@ class UtilsTestCase(unittest.TestCase):
         something = durationHuman(364020)
         self.assertEqual(something, "4.0 days 05:07:00")
 
+    def test_get_endpoints_from_section(self):
+        cfg = get_config(b"""
+            [ssh]
+            listen_addr = 1.1.1.1
+        """)
+        self.assertEqual(["tcp:2223:interface=1.1.1.1"], get_endpoints_from_section(cfg, "ssh", 2223))
+
+        cfg = get_config(b"""
+            [ssh]
+            listen_addr = 1.1.1.1
+        """)
+        self.assertEqual(["tcp:2224:interface=1.1.1.1"], get_endpoints_from_section(cfg, "ssh", 2224))
+
+        cfg = get_config(b"""
+            [ssh]
+            listen_addr = 1.1.1.1 2.2.2.2
+        """)
+        self.assertEqual(["tcp:2223:interface=1.1.1.1", "tcp:2223:interface=2.2.2.2"], get_endpoints_from_section(cfg, "ssh", 2223))
+
+        cfg = get_config(b"""
+            [ssh]
+            listen_addr = 1.1.1.1 2.2.2.2
+            listen_port = 23
+        """)
+        self.assertEqual(["tcp:23:interface=1.1.1.1", "tcp:23:interface=2.2.2.2"], get_endpoints_from_section(cfg, "ssh", 2223))
+
+        cfg = get_config(b"""
+            [ssh]
+            listen_endpoints = tcp:23:interface=1.1.1.1 tcp:2323:interface=1.1.1.1
+        """)
+        self.assertEqual(["tcp:23:interface=1.1.1.1", "tcp:2323:interface=1.1.1.1"], get_endpoints_from_section(cfg, "ssh", 2223))
+
+    def test_create_endpoint_services(self):
+        parent = MultiService()
+        create_endpoint_services(reactor, parent, [b"tcp:23:interface=1.1.1.1"], protocol.Factory())
+        self.assertEqual(len(parent.services), 1)
+
+        parent = MultiService()
+        create_endpoint_services(reactor, parent, [u"tcp:23:interface=1.1.1.1"], protocol.Factory())
+        self.assertEqual(len(parent.services), 1)
+
+        parent = MultiService()
+        create_endpoint_services(reactor, parent, ["tcp:23:interface=1.1.1.1", "tcp:2323:interface=2.2.2.2"], protocol.Factory())
+        self.assertEqual(len(parent.services), 2)


### PR DESCRIPTION
This PR does 2 main things:

 * Replace `internet.TCPServer` with `serverFromString` and `StreamServerEndpointService` (See [here](https://twistedmatrix.com/documents/current/core/howto/endpoints.html))
 * Expose a new `listen_endpoint` setting for `[ssh]` and `[telnet]` that lets the user use endpoints.

But i've pulled the code into `cowrie/` so i can import and test it as well.

This lets you do 2 things. You can listen on multiple ports:

```
[tcp]
enabled = yes
listen_endpoints = tcp:23:interface=0.0.0.0 tcp:2323:interface=0.0.0.0
```

The correct ports will be reported (unless you've got `reported_port` on).

And you can use cowrie with systemd socket activation. This means systemd can open low ports for you and you don't need iptables rules or `reported_port` settings. There is a simple example [here](https://twistedmatrix.com/documents/current/core/howto/systemd.html#socket-activation). And here is an example setup after applying this patch:

/etc/systemd/system/cowrie.socket:
```
[Unit]
Description=Socket for cowrie

[Socket]
ListenStream=0.0.0.0:22
ListenStream=0.0.0.0:23
ListenStream=0.0.0.0:2323
Service = cowrie.service

[Install]
WantedBy = sockets.target
```

/etc/systemd/system/cowrie.service:
```
[Unit]
Description=Cowrie SSH and Telnet Honeypots
Documentation=https://github.com/micheloosterhof/cowrie
After=network.target
Requires=cowrie.socket

[Service]
Type=simple
User=cowrie
Group=cowrie
Environment=PYTHONPATH=/home/cowrie/cowrie:/usr/lib/python2.7:/usr/lib/python2.7/plat-x86_64-linux-gnu:/usr/lib/python2.7/lib-tk:/usr/lib/python2.7/lib-old:/usr/lib/python2.7/lib-dynload:/home/cowrie/.local/lib/python2.7/site-packages:/usr/local/lib/python2.7/dist-packages:/usr/lib/python2.7/dist-packages
Environment=PYTHONUNBUFFERED=true
ExecStart=/home/cowrie/.local/bin/twistd -n -l - --umask 0077 --pidfile= cowrie -c cowrie.cfg
WorkingDirectory=/home/cowrie/cowrie/
Restart=always
TimeoutSec=300
NonBlocking=yes

[Install]
WantedBy=multi-user.target
```

And in cowrie.cfg:
```
[ssh]
enabled = true
listen_endpoints = systemd:domain=INET:index=0

[telnet]
enabled = true
listen_endpoints = systemd:domain=INET:index=1 systemd:domain=INET:index=2
```

Fun side effect of this setup: You can extend it with the `ReusePort` socket setting to scale cowrie over multiple cores, as described [here](https://unrouted.io/ops/2017/04/26/multicore-twistd-with-systemd/).