### PR TITLE
Fix command line option handling

### DIFF
--- a/bin/cowrie
+++ b/bin/cowrie
@@ -91,20 +91,22 @@ set -e
 
 for key in "$@"
 do
-    key=$1
     case $key in 
         stop)
-            cowrie_stop
+		    func() { cowrie_stop; }
             ;;
         start)
-            cowrie_start
+		    func() { cowrie_start; }
             ;;
         status)
-            cowrie_status
+		    func() { cowrie_status; }
             ;;
+        -n)
+            DAEMONIZE="-n"
+	        ;;
         *)
-            cowrie_usage
-            exit 1
+		func() { cowrie_usage; }
             ;;
     esac
 done
+func


### PR DESCRIPTION
If "-n" command line option was given, the script tried to start cowrie twice. 
 => Added handling for the -n command line parameter and made the handling "order independent"