### PR TITLE
Add support for cowrie args in start script

### DIFF
--- a/bin/cowrie
+++ b/bin/cowrie
@@ -51,7 +51,7 @@ cowrie_start() {
     then
         activate_venv "cowrie-env"
     fi
-    echo "Starting cowrie with extra arguments [$XARGS $DAEMONIZE] ..."
+    echo "Starting cowrie with extra arguments [twistd $XARGS $DAEMONIZE cowrie $COWRIEARGS] ..."
     if [ $AUTHBIND_ENABLED = "no" ]
     then
         twistd $XARGS $DAEMONIZE -l log/cowrie.log --umask 0077 --pidfile ${PIDFILE} cowrie $COWRIEARGS

--- a/bin/cowrie
+++ b/bin/cowrie
@@ -54,9 +54,9 @@ cowrie_start() {
     echo "Starting cowrie with extra arguments [$XARGS $DAEMONIZE] ..."
     if [ $AUTHBIND_ENABLED = "no" ]
     then
-        twistd $XARGS $DAEMONIZE -l log/cowrie.log --umask 0077 --pidfile ${PIDFILE} cowrie
+        twistd $XARGS $DAEMONIZE -l log/cowrie.log --umask 0077 --pidfile ${PIDFILE} cowrie $COWRIEARGS
     else
-        authbind --deep twistd $XARGS -l log/cowrie.log --umask 0077 --pidfile ${PIDFILE} cowrie
+        authbind --deep twistd $XARGS -l log/cowrie.log --umask 0077 --pidfile ${PIDFILE} cowrie $COWRIEARGS
     fi
 }
 
@@ -74,7 +74,7 @@ cowrie_usage() {
 }
 
 ################################################################################
-## Main script 
+## Main script
 ################################################################################
 
 if [ "$#" = 0 ]
@@ -92,7 +92,7 @@ set -e
 for key in "$@"
 do
     key=$1
-    case $key in 
+    case $key in
         stop)
             cowrie_stop
             ;;


### PR DESCRIPTION
Right now the `bin/cowrie` start script only support extra arguments using the ENV variable XARGS. These arguments are passed to twistd. If we want to start cowrie with extra arguments (e.g.: --config) we need an additional ENV variable.

You can now run `bin/cowrie start` with `"COWRIEARGS=--config /etc/cowrie.cfg"` as ENV variable.