### PR TITLE
Report actual path in redir event

### DIFF
--- a/cowrie/core/protocol.py
+++ b/cowrie/core/protocol.py
@@ -204,7 +204,10 @@ class HoneyPotBaseProtocol(insults.TerminalProtocol, TimeoutMixin):
         obj.start()
         if hasattr(obj, 'safeoutfile'):
             if obj.safeoutfile:
-                self.terminal.redirFiles.add(obj.safeoutfile)
+                if hasattr(obj, 'outfile'):
+                    self.terminal.redirFiles.add((obj.safeoutfile, obj.outfile))
+                else:
+                    self.terminal.redirFiles.add((obj.safeoutfile, ''))
         if self.pp:
             self.pp.outConnectionLost()
 

--- a/cowrie/insults/insults.py
+++ b/cowrie/insults/insults.py
@@ -22,6 +22,7 @@ class LoggingServerProtocol(insults.ServerProtocol):
     """
     stdinlogOpen = False
     ttylogOpen = False
+    redirlogOpen = False  # it will be set at core/protocol.py
 
     def __init__(self, prot=None, *a, **kw):
         insults.ServerProtocol.__init__(self, prot, *a, **kw)
@@ -163,7 +164,15 @@ class LoggingServerProtocol(insults.ServerProtocol):
                 self.stdinlogOpen = False
 
         if self.redirFiles:
-            for rf in self.redirFiles:
+            for rp in self.redirFiles:
+
+                rf = rp[0]
+
+                if rp[1]:
+                    url = rp[1]
+                else:
+                    url = rf[rf.find('redir_')+len('redir_'):]
+                    
                 try:
                     if not os.path.exists(rf):
                         continue
@@ -183,7 +192,7 @@ class LoggingServerProtocol(insults.ServerProtocol):
                         os.symlink(shasum, rf)
                     log.msg(eventid='cowrie.session.file_download',
                             format='Saved redir contents with SHA-256 %(shasum)s to %(outfile)s',
-                            url='redir',
+                            url=url,
                             outfile=shasumfile,
                             shasum=shasum)
                 except IOError:


### PR DESCRIPTION
Having "redir" as "URL" in cowrie.session.file_download event is useless.

The PR replaces "redir" with actual path where malware tries to store its data.