### PR TITLE
Python: Fixed hang & version printing

### DIFF
--- a/cowrie/commands/python.py
+++ b/cowrie/commands/python.py
@@ -16,11 +16,8 @@ class command_python(HoneyPotCommand):
     """
     """
     def version(self):
-        output = (
-            'Python 2.7.11+'
-        )
-        for l in output:
-            self.write(l + '\n')
+        ver = 'Python 2.7.11+'
+        self.write(ver + '\n')
         self.exit()
 
 
@@ -89,19 +86,20 @@ class command_python(HoneyPotCommand):
 
         # Parse options
         for o, a in opts:
-            if o in ("-v"):
+            if o in "-V":
                 self.version()
                 self.exit()
                 return
-            elif o in ("--help"):
+            elif o in "--help":
                 self.help()
                 self.exit()
                 return
-            elif o in ('-h'):
+            elif o in '-h':
                 self.help()
                 self.exit()
-            elif o in ('--version'):
+            elif o in '--version':
                 self.version()
+                self.exit()
 
         for value in args:
             sourcefile = self.fs.resolve_path(value, self.protocol.cwd)

--- a/cowrie/commands/python.py
+++ b/cowrie/commands/python.py
@@ -18,7 +18,6 @@ class command_python(HoneyPotCommand):
     def version(self):
         ver = 'Python 2.7.11+'
         self.write(ver + '\n')
-        self.exit()
 
 
     def help(self):
@@ -97,9 +96,11 @@ class command_python(HoneyPotCommand):
             elif o in '-h':
                 self.help()
                 self.exit()
+                return
             elif o in '--version':
                 self.version()
                 self.exit()
+                return
 
         for value in args:
             sourcefile = self.fs.resolve_path(value, self.protocol.cwd)


### PR DESCRIPTION
* There was a hang caused by exit() in the version() func and followed by exit() in the start() function.
* Printing version in python requires `-V` switch, not `-v`.
* version() func was bugged and printed one character per line, instead of full string