### PR TITLE
fix for unicode url issue - splunk.py

### DIFF
--- a/cowrie/output/splunk.py
+++ b/cowrie/output/splunk.py
@@ -9,6 +9,7 @@ JSON log file is still recommended way to go
 from StringIO import StringIO
 
 import json
+import unicodedata
 
 from twisted.python import log
 from twisted.internet import reactor
@@ -29,6 +30,7 @@ class Output(cowrie.core.output.Output):
         """
         self.token = cfg.get('output_splunk', 'token')
         self.url = cfg.get('output_splunk', 'url')
+        self.url = unicodedata.normalize('NFKD',self.url).encode('ascii','ignore')
         try:
             self.index = cfg.get('output_splunk', 'index')
         except:


### PR DESCRIPTION
fix for the following error:
[twisted.logger._observer#critical] Temporarily disabling observer LegacyLogObserverWrapper(<bound method Output.emit of <cowrie.output.splunk.Output object at 0x3230d50>>) due to exception: [Failure instance: Traceback: <type 'exceptions.TypeError'>: url must be bytes, not unicode