### PR TITLE
Change path for systemd-unit

### DIFF
--- a/doc/systemd/README.md
+++ b/doc/systemd/README.md
@@ -1,6 +1,6 @@
 # Automatically starting Cowrie with systemd
 
-* Copy the file `cowrie.service` to `/etc/systemd/service`
+* Copy the file `cowrie.service` to `/etc/systemd/system/`
 * Reload systemd with `systemctl daemon-reload`
 * Start Cowrie with `service cowrie start`
 * Enable start at boot-time with `sudo systemctl enable cowrie.service``


### PR DESCRIPTION
The path /etc/systemd/service/ does not exist on Debian 8/9, CentOS 7 and SLES 12
Really funny for linux beginners do read the whole systemd documentation ...