### PR TITLE
Prevent crash if connection is already lost

### DIFF
--- a/cowrie/core/honeypot.py
+++ b/cowrie/core/honeypot.py
@@ -544,7 +544,8 @@ class StdOutStdErrEmulationProtocol(object):
     def errReceived(self, data):
         """
         """
-        self.protocol.terminal.write(data)
+        if self.protocol and self.protocol.terminal:
+            self.protocol.terminal.write(data)
         self.err_data = self.err_data + data
 
 


### PR DESCRIPTION
If something went wrong and connection dropped, we'll crash while trying to display a error in terminal.

This PR ensures that terminal is not freed before trying to use it.