### PR TITLE
Explicitly state protocol in hpfeeds event

### DIFF
--- a/cowrie/output/hpfeeds.py
+++ b/cowrie/output/hpfeeds.py
@@ -291,7 +291,7 @@ class Output(cowrie.core.output.Output):
                 'hostIP': entry["dst_ip"], 'hostPort': entry["dst_port"],
                 'loggedin': None, 'credentials':[], 'commands':[],
                 'unknownCommands':[], 'urls':[], 'version': None,
-                'ttylog': None, 'hashes': set()}
+                'ttylog': None, 'hashes': set(), 'protocol': entry['protocol']}
 
         elif entry["eventid"] == 'cowrie.login.success':
             u, p = entry['username'], entry['password']

--- a/cowrie/ssh/transport.py
+++ b/cowrie/ssh/transport.py
@@ -41,7 +41,7 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
            format='New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s) [session: %(session)s]',
            src_ip=src_ip, src_port=self.transport.getPeer().port,
            dst_ip=self.transport.getHost().host, dst_port=self.transport.getHost().port,
-           session=self.transportId, sessionno='S'+str(self.transport.sessionno))
+           session=self.transportId, sessionno='S'+str(self.transport.sessionno), protocol='ssh')
 
         self.transport.write('{}\r\n'.format(self.ourVersionString))
         self.currentEncryptions = transport.SSHCiphers('none', 'none', 'none', 'none')

--- a/cowrie/telnet/transport.py
+++ b/cowrie/telnet/transport.py
@@ -215,7 +215,7 @@ class CowrieTelnetTransport(TelnetTransport, TimeoutMixin):
            format='New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s) [session: T%(sessionno)s]',
            src_ip=self.transport.getPeer().host, src_port=self.transport.getPeer().port,
            dst_ip=self.transport.getHost().host, dst_port=self.transport.getHost().port,
-           session=self.transportId, sessionno='T'+str(sessionno))
+           session=self.transportId, sessionno='T'+str(sessionno), protocol='telnet')
         TelnetTransport.connectionMade(self)
 
 


### PR DESCRIPTION
When listening on multiple ports its not easy to filter by ssh vs telnet so i added something explicit to the hpfeeds event.