### PR TITLE
Add S3 artifact upload output plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* 2017-10-24 Can store uploaded and downloaded artifacts to S3
 * 2017-09-23 First proxy implementation for exec commands only
 * 2017-07-03 Cuckoo v2 integration
 * 2017-05-16 now combines config files: cowrie.cfg.dist and cowrie.cfg in this order

--- a/cowrie.cfg.dist
+++ b/cowrie.cfg.dist
@@ -515,3 +515,27 @@ logfile = log/cowrie.json
 #[output_socketlog]
 #address = 127.0.0.1:9000
 #timeout = 5
+
+# Upload files that cowrie has captured to an S3 (or compatible bucket)
+# Files are stored with a name that is the SHA of their contents
+#
+#[output_s3]
+#
+# The AWS credentials to use
+#access_key_id = AKIDEXAMPLE
+#secret_access_key = wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY
+#
+# The bucket to store the files in. The bucket must already exist.
+#bucket = my-cowrie-bucket
+#
+# The region the bucket is in
+#region = eu-west-1
+#
+# An alternate endpoint URL. If you self host a pithos instance you can set
+# this to its URL (e.g. https://s3.mydomain.com) - can otherwise be blank
+#endpoint =
+#
+# Whether or not to validate the S3 certificate. Set this to 'no' to turn this
+# off. Do not do this for real AWS. It's only needed for self-hosted S3 clone
+# where you don't yet have real certificates.
+#verify = no

--- a/cowrie/output/s3.py
+++ b/cowrie/output/s3.py
@@ -1,0 +1,86 @@
+"""
+Send downloaded/uplaoded files to S3 (or compatible)
+"""
+
+from __future__ import division, absolute_import
+
+import os
+
+from twisted.internet import defer, threads
+
+from botocore.session import get_session
+from botocore.exceptions import ClientError
+
+import cowrie.core.output
+
+
+class Output(cowrie.core.output.Output):
+
+    def __init__(self, cfg):
+        self.seen = set()
+
+        self.session = get_session()
+        self.session.set_credentials(
+            cfg.get("output_s3", "access_key_id"),
+            cfg.get("output_s3", "secret_access_key"),
+        )
+        self.client = self.session.create_client(
+            's3',
+            region_name=cfg.get("output_s3", "region"),
+            endpoint_url=cfg.get("output_s3", "endpoint") or None,
+            verify=False if cfg.get("output_s3", "verify") == "no" else True,
+        )
+        self.bucket = cfg.get("output_s3", "bucket")
+        cowrie.core.output.Output.__init__(self, cfg)
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def write(self, entry):
+        if entry["eventid"] == "cowrie.session.file_download":
+            self.upload(entry['shasum'], entry["outfile"])
+
+        elif entry["eventid"] == "cowrie.session.file_upload":
+            self.upload(entry['shasum'], entry['outfile'])
+
+    @defer.inlineCallbacks
+    def _object_exists_remote(self, shasum):
+        try:
+            yield threads.deferToThread(
+                self.client.head_object,
+                Bucket=self.bucket,
+                Key=shasum,
+            )
+        except ClientError as e:
+            if e.response['Error']['Code'] == '404':
+                defer.returnValue(False)
+            raise
+
+        defer.returnValue(True)
+
+    @defer.inlineCallbacks
+    def upload(self, shasum, filename):
+        if shasum in self.seen:
+            print("Already uploaded file with sha {} to S3".format(shasum))
+            return
+
+        exists = yield self._object_exists_remote(shasum)
+        if exists:
+            print("Somebody else already uploaded file with sha {} to S3".format(shasum))
+            self.seen.add(shasum)
+            return
+
+        print("Uploading file with sha {} ({}) to S3".format(shasum, filename))
+        with open(filename, 'rb') as fp:
+            yield threads.deferToThread(
+                self.client.put_object,
+                Bucket=self.bucket,
+                Key=shasum,
+                Body=fp.read(),
+                ContentType='application/octet-stream',
+            )
+
+        self.seen.add(shasum)

--- a/requirements-output.txt
+++ b/requirements-output.txt
@@ -16,6 +16,9 @@ pymongo
 # rethinkdblog
 rethinkdb
 
+# s3
+botocore
+
 # slack
 slackclient
 


### PR DESCRIPTION
If you run multiple cowrie you might want to collect artifacts in a central location. S3 seems like a good choice (i actually store it on an s3 compatible service, hence the `endpoint` setting).

I chose `botocore` and `deferToThread` as `botocore` is very well supported. `txAWS` is supported but there are gaps (I would have had to use monkey patches to expose the settings I have used in this PR).