### PR TITLE
Fix bug in parsing argument for ping command

### DIFF
--- a/cowrie/commands/ping.py
+++ b/cowrie/commands/ping.py
@@ -37,7 +37,7 @@ class command_ping(HoneyPotCommand):
         self.running = False
 
         try:
-            optlist, args = getopt.getopt(self.args, "c:")
+            optlist, args = getopt.gnu_getopt(self.args, "c:")
         except getopt.GetoptError as err:
             self.write('ping: %s\n' % (err,))
             self.exit()


### PR DESCRIPTION
>`gnu_getopt()` - This function works like getopt(), except that GNU style scanning mode is used by default. This means that option and non-option arguments may be intermixed. The getopt() function stops processing options as soon as a non-option argument is encountered.