### PR TITLE
Symbolic Link Command Fix

### DIFF
--- a/cowrie/shell/fs.py
+++ b/cowrie/shell/fs.py
@@ -230,7 +230,7 @@ class HoneyPotFilesystem(object):
                             return False
                     else:
                         p = x
-            cwd = '/'.join((cwd, piece))
+            # cwd = '/'.join((cwd, piece))
         return p
 
 


### PR DESCRIPTION
(#640) All relative symbolic link commands are currently broken and receive the response `bash: command not found: x` in the honeypot shell.  The path is not being traversed correctly and fs.HoneyPotFilesystem.getfile() appears to be the source of problem.  Removing the cwd join command resolves the issue but I am not aware of other potential side effects.

The problem was first noted with `sh`.  I made `echo` a symbolic link and it failed in the same way.  Applying this fix corrected both on my system.