### PR TITLE
send correct ttylog to hpfeeds

### DIFF
--- a/cowrie/output/hpfeeds.py
+++ b/cowrie/output/hpfeeds.py
@@ -324,7 +324,7 @@ class Output(cowrie.core.output.Output):
         elif entry["eventid"] == 'cowrie.log.closed':
             # entry["ttylog"]
             with open( entry["ttylog"]) as ttylog:
-                self.meta['ttylog'] = ttylog.read().encode('hex')
+                self.meta[session]['ttylog'] = ttylog.read().encode('hex')
 
         elif entry["eventid"] == 'cowrie.session.closed':
             log.msg('publishing metadata to hpfeeds')


### PR DESCRIPTION
1.fix hpfeeds message 'ttylog' field is always null.