### PR TITLE
Removed duplicate key "jobs" in expected_results.json.

### DIFF
--- a/cowrie/test/expected_results.json
+++ b/cowrie/test/expected_results.json
@@ -7,7 +7,6 @@
     "chattr":  [ "root@unitTest:~# " ],
     "chgrp":  [ "root@unitTest:~# " ],
     "chown":  [ "root@unitTest:~# " ],
-    "jobs":  [ "root@unitTest:~# " ],
     "kill":  [ "root@unitTest:~# " ],
     "su":  [ "root@unitTest:~# " ],
     "jobs":  [ "root@unitTest:~# " ],


### PR DESCRIPTION
The "jobs" key is two times in the JSON.