### PR TITLE
Accept wildcard for username in userdb.txt

### DIFF
--- a/cowrie/core/auth.py
+++ b/cowrie/core/auth.py
@@ -64,14 +64,14 @@ class UserDB(object):
         """
         check entered username/password against database
         note that it allows multiple passwords for a single username
-        it also knows wildcard '*' for any password
+        it also knows wildcard '*' for any username or password 
         prepend password with ! to explicitly deny it. Denials must come before wildcards
         """
         for (login, passwd) in self.userdb:
             # Explicitly fail on !password
             if login == thelogin and passwd == b'!' + thepasswd:
                 return False
-            if login == thelogin and passwd in (thepasswd, b'*'):
+            if login in (thelogin, b'*') and passwd in (thepasswd, b'*'):
                 return True
         return False
 


### PR DESCRIPTION
This change will handle wildcards for usernames the same as for passwords, in userdb.txt.