### PR TITLE
Support for cowrie.session.file_download.failed in SQL output modules

### DIFF
--- a/cowrie/output/mysql.py
+++ b/cowrie/output/mysql.py
@@ -158,6 +158,13 @@ class Output(cowrie.core.output.Output):
                 ' VALUES (%s, FROM_UNIXTIME(%s), %s, %s, %s)',
                 (entry["session"], entry["time"],
                 entry['url'], entry['outfile'], entry['shasum']))
+	
+        elif entry["eventid"] == 'cowrie.session.file_download.failed':
+            self.simpleQuery('INSERT INTO `downloads`' + \
+                ' (`session`, `timestamp`, `url`, `outfile`, `shasum`)' + \
+                ' VALUES (%s, FROM_UNIXTIME(%s), %s, %s, %s)',
+                (entry["session"], entry["time"],
+                entry['url'], 'NULL', 'NULL'))
 
         elif entry["eventid"] == 'cowrie.session.file_upload':
             self.simpleQuery('INSERT INTO `downloads`' + \

--- a/cowrie/output/sqlite.py
+++ b/cowrie/output/sqlite.py
@@ -111,13 +111,20 @@ class Output(cowrie.core.output.Output):
                 ' VALUES (?, ?, ?, ?)',
                 (entry["session"], entry["timestamp"],
                 0, entry["input"]))
-
+ 
         elif entry["eventid"] == 'cowrie.session.file_download':
             self.simpleQuery('INSERT INTO `downloads`' + \
                 ' (`session`, `timestamp`, `url`, `outfile`, `shasum`)' + \
                 ' VALUES (?, ?, ?, ?, ?)',
                 (entry["session"], entry["timestamp"],
                 entry['url'], entry['outfile'], entry['shasum']))
+
+        elif entry["eventid"] == 'cowrie.session.file_download.failed':
+            self.simpleQuery('INSERT INTO `downloads`' + \
+                ' (`session`, `timestamp`, `url`, `outfile`, `shasum`)' + \
+                ' VALUES (?, ?, ?, ?, ?)',
+                (entry["session"], entry["timestamp"],
+                entry['url'], 'NULL', 'NULL'))
 
         elif entry["eventid"] == 'cowrie.session.file_download':
             self.simpleQuery('INSERT INTO `input`' + \

--- a/doc/sql/mysql.sql
+++ b/doc/sql/mysql.sql
@@ -56,7 +56,7 @@ CREATE TABLE IF NOT EXISTS `downloads` (
   `session` CHAR( 32 ) NOT NULL,
   `timestamp` datetime NOT NULL,
   `url` text NOT NULL,
-  `outfile` text NOT NULL,
+  `outfile` text default NULL,
   `shasum` varchar(64) default NULL,
   PRIMARY KEY  (`id`),
   KEY `session` (`session`,`timestamp`)

--- a/doc/sql/sqlite3.sql
+++ b/doc/sql/sqlite3.sql
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS `downloads` (
   `session` CHAR( 32 ) NOT NULL,
   `timestamp` datetime NOT NULL,
   `url` text NOT NULL,
-  `outfile` text NOT NULL,
+  `outfile` text default NULL,
   `shasum` varchar(64) default NULL
 ) ;
 CREATE INDEX downloads_index ON downloads(session, timestamp);

--- a/doc/sql/update12.sql
+++ b/doc/sql/update12.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `downloads` MODIFY `outfile` text default NULL;


### PR DESCRIPTION
I have added the support for cowrie.session.file_download.failed on the SQL output modules and SQL schemas for DB