### PR TITLE
Update elasticsearch output module in order to use official python library

### DIFF
--- a/cowrie/output/elasticsearch.py
+++ b/cowrie/output/elasticsearch.py
@@ -2,7 +2,7 @@
 
 from __future__ import division, absolute_import
 
-import pyes
+from elasticsearch import Elasticsearch
 
 import cowrie.core.output
 
@@ -19,7 +19,7 @@ class Output(cowrie.core.output.Output):
         """
         self.host = CONFIG.get('output_elasticsearch', 'host')
         self.port = CONFIG.get('output_elasticsearch', 'port')
-        self.index =CONFIGg.get('output_elasticsearch', 'index')
+        self.index =CONFIG.get('output_elasticsearch', 'index')
         self.type = CONFIG.get('output_elasticsearch', 'type')
         cowrie.core.output.Output.__init__(self)
 
@@ -27,7 +27,7 @@ class Output(cowrie.core.output.Output):
     def start(self):
         """
         """
-        self.es = pyes.ES('{0}:{1}'.format(self.host, self.port))
+        self.es = Elasticsearch('{0}:{1}'.format(self.host, self.port))
 
 
     def stop(self):
@@ -44,5 +44,4 @@ class Output(cowrie.core.output.Output):
             if i.startswith('log_'):
                 del logentry[i]
 
-        self.es.index(logentry, self.index, self.type)
-
+        self.es.index(index=self.index, doc_type=self.type, body=logentry)

--- a/requirements-output.txt
+++ b/requirements-output.txt
@@ -5,7 +5,7 @@ csirtgsdk>=0.0.0a17 # Specify version because pip won't install pre-release vers
 requests
 
 # elasticsearch
-pyes
+elasticsearch
 
 # mysql
 # If this fails, see documentation /home/cowrie/cowrie/doc/sql/README.md


### PR DESCRIPTION
The official elasticsearch python library supports elasticsearch 5.x and 6.x (pyes generates errors with el 6.x)