### PR TITLE
Fallback to botocore credential discovery

### DIFF
--- a/cowrie.cfg.dist
+++ b/cowrie.cfg.dist
@@ -531,7 +531,9 @@ logfile = log/cowrie.json
 #
 #[output_s3]
 #
-# The AWS credentials to use
+# The AWS credentials to use.
+# Leave these blank to use botocore's credential discovery e.g .aws/config or ENV variables.
+# As per https://github.com/boto/botocore/blob/develop/botocore/credentials.py#L50-L65
 #access_key_id = AKIDEXAMPLE
 #secret_access_key = wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY
 #


### PR DESCRIPTION
Use-case: Authenticating to an S3 bucket using system-wide, dynamically-provisioned AWS credentials via [IAM instance roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html).

By omitting **set_credentials()** botocore searches for credentials in various [default locations](http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials)



