### PR TITLE
Extend redis output by password + publish capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ __pycache__/
 twisted/plugins/dropin.cache
 .DS_Store
 _trial_temp
-
+.project
+.pydevproject

--- a/cowrie.cfg.dist
+++ b/cowrie.cfg.dist
@@ -558,7 +558,21 @@ logfile = log/cowrie.json
 
 
 #[output_redis]
+# Host of the redis server. Required
 #host = 127.0.0.1
+
+# Port of the redis server. Required
 #port = 6379
+
+# DB of the redis server. Defaults to 0
 #db = 0
+
+# Password of the redis server. Defaults to None
+#password = secret
+
+# Name of the list to push to or the channel to publish to. Required
 #keyname = cowrie
+
+# Method to use when sending data to redis.
+# Can be one of [lpush, rpush, publish]. Defaults to lpush
+#send_method = lpush

--- a/cowrie/output/redis.py
+++ b/cowrie/output/redis.py
@@ -8,9 +8,9 @@ import json
 from ConfigParser import NoOptionError
 
 SEND_METHODS = {
-    'lpush': lambda redis, key, message: redis.lpush(key, message),
-    'rpush': lambda redis, key, message: redis.rpush(key, message),
-    'publish': lambda redis, key, message: redis.publish(key, message),
+    'lpush': lambda redis_client, key, message: redis_client.lpush(key, message),
+    'rpush': lambda redis_client, key, message: redis_client.rpush(key, message),
+    'publish': lambda redis_client, key, message: redis_client.publish(key, message),
 }
 
 class Output(cowrie.core.output.Output):

--- a/cowrie/output/redis.py
+++ b/cowrie/output/redis.py
@@ -58,4 +58,4 @@ class Output(cowrie.core.output.Output):
             # Remove twisted 15 legacy keys
             if i.startswith('log_'):
                 del logentry[i]
-        self._send_method(self.redis, self.keyname, json.dumps(logentry))
+        self.send_method(self.redis, self.keyname, json.dumps(logentry))


### PR DESCRIPTION
Hi,
these changes allow specifying a password for the redis connection and choosing between different options to send logs to redis. Publish allows pub/sub usage and thus removes the need of handling list length.
The changes should be backwards compatible with existing redis configurations due to sensible defaults.
