### PR TITLE
Support reading all config vars from env

### DIFF
--- a/cowrie/core/config.py
+++ b/cowrie/core/config.py
@@ -8,6 +8,26 @@ This module contains ...
 from __future__ import division, absolute_import
 
 import configparser
+import os
+
+
+def to_environ_key(key):
+    return key.upper()
+
+
+class EnvironmentConfigParser(configparser.ConfigParser):
+
+    def has_option(self, section, option):
+        if to_environ_key('_'.join((section, option))) in os.environ:
+            return True
+        return super(EnvironmentConfigParser, self).has_option(section, option)
+
+    def get(self, section, option, **kwargs):
+        key = to_environ_key('_'.join((section, option)))
+        if key in os.environ:
+            return os.environ[key]
+        return super(EnvironmentConfigParser, self).get(section, option, **kwargs)
+
 
 def readConfigFile(cfgfile):
     """
@@ -16,9 +36,8 @@ def readConfigFile(cfgfile):
     @param cfgfile: filename or array of filenames
     @return: ConfigParser object
     """
-    parser = configparser.ConfigParser()
+    parser = EnvironmentConfigParser()
     parser.read(cfgfile)
     return parser
 
 CONFIG = readConfigFile(("cowrie.cfg.dist", "etc/cowrie.cfg", "cowrie.cfg"))
-


### PR DESCRIPTION
This PR lets you override any config variable from env. This is really meant for the Docker case. 