### PR TITLE
Allow customization of 'uname -a' response via config file

### DIFF
--- a/cowrie.cfg.dist
+++ b/cowrie.cfg.dist
@@ -109,6 +109,11 @@ interactive_timeout = 180
 # (default: shell)
 backend = shell
 
+# Modify the response of '/bin/uname'
+# Default (uname -a): Linux <hostname> <kernel_version> <kernel_build_string> <hardware_platform> GNU/Linux
+kernel_version = 3.2.0-4-amd64
+kernel_build_string = #1 SMP Debian 3.2.68-1+deb7u1
+hardware_platform = x86_64
 
 
 # ============================================================================
@@ -396,7 +401,7 @@ forward_tunnel = false
 [telnet]
 
 # Enable Telnet support, disabled by default
-enabled = false
+enabled = true
 
 # IP addresses to listen for incoming Telnet connections.
 # (DEPRECATED: use listen_endpoints instead)

--- a/cowrie.cfg.dist
+++ b/cowrie.cfg.dist
@@ -401,7 +401,7 @@ forward_tunnel = false
 [telnet]
 
 # Enable Telnet support, disabled by default
-enabled = true
+enabled = false
 
 # IP addresses to listen for incoming Telnet connections.
 # (DEPRECATED: use listen_endpoints instead)

--- a/cowrie/commands/uname.py
+++ b/cowrie/commands/uname.py
@@ -2,20 +2,79 @@
 
 from __future__ import division, absolute_import
 
+from cowrie.core.config import CONFIG
+from configparser import NoOptionError
+
 from cowrie.shell.honeypot import HoneyPotCommand
 
 commands = {}
 
 class command_uname(HoneyPotCommand):
+
+    def help(self):
+        return '''Usage: uname [OPTION]...
+Print certain system information.  With no OPTION, same as -s.
+
+  -a, --all                print all information, in the following order,
+                             except omit -p and -i if unknown:
+  -s, --kernel-name        print the kernel name
+  -n, --nodename           print the network node hostname
+  -r, --kernel-release     print the kernel release
+  -v, --kernel-version     print the kernel version
+  -m, --machine            print the machine hardware name
+  -p, --processor          print the processor type (non-portable)
+  -i, --hardware-platform  print the hardware platform (non-portable)
+  -o, --operating-system   print the operating system
+      --help     display this help and exit
+      --version  output version information and exit
+
+GNU coreutils online help: <http://www.gnu.org/software/coreutils/>
+Full documentation at: <http://www.gnu.org/software/coreutils/uname>
+or available locally via: info '(coreutils) uname invocation'\n
+'''
+
+    def hardware_platform(self):
+        try:
+            return CONFIG.get("honeypot", "hardware_platform")
+        except NoOptionError:
+            return 'x86_64'
+
+    def kernel_version(self):
+        try:
+            return CONFIG.get("honeypot", "kernel_version")
+        except NoOptionError:
+            return '3.2.0-4-amd64'
+
+    def kernel_build_string(self):
+        try:
+           return CONFIG.get("honeypot", "kernel_build_string")
+        except NoOptionError:
+           return '#1 SMP Debian 3.2.68-1+deb7u1'
+
+    def operating_system(self):
+        return 'GNU/Linux'
+
+    def full_uname(self):
+        return 'Linux %s %s %s %s %s\n' % ( self.protocol.hostname,
+                                            self.kernel_version(),
+                                            self.kernel_build_string(),
+                                            self.hardware_platform(),
+                                            self.operating_system() )
+
+
     def call(self):
         if len(self.args) and self.args[0].strip() in ('-a', '--all'):
-            self.write(
-                'Linux %s 3.2.0-4-amd64 #1 SMP Debian 3.2.68-1+deb7u1 x86_64 GNU/Linux\n' % \
-                self.protocol.hostname)
+            self.write(self.full_uname())
         elif len(self.args) and self.args[0].strip() in ('-r', '--kernel-release'):
-            self.write( '3.2.0-4-amd64\n' )
-        elif len(self.args) and self.args[0].strip() in ('-m', '--machine'):
-            self.write( 'amd64\n' )
+            self.write( '%s\n' % self.kernel_version() )
+        elif len(self.args) and self.args[0].strip() in ('-o', '--operating-system'):
+            self.write( '%s\n' % self.operating_system() )
+        elif len(self.args) and self.args[0].strip() in ('-n', '--nodename'):
+            self.write( '%s\n' % self.protocol.hostname )
+        elif len(self.args) and self.args[0].strip() in ('-m', '--machine', '-p', '--processor', '-i', '--hardware-platform'):
+            self.write( '%s\n' % self.hardware_platform() )
+        elif len(self.args) and self.args[0].strip() in ('-h', '--help'):
+            self.write( self.help() )
         else:
             self.write('Linux\n')
 


### PR DESCRIPTION
### Overview
Allow customization of 'uname' responses via config.

### Usecases
1. Make it a little harder to detecting the honeypot by using non-standard uname responses
2. Attempt to measure any differences in hit-rate against the honeypot by pretending to be a different hardware platform.

### Testing
Responses with custom entries in config file
```
root@svr04:~# uname -r
Custom_kernel_version
root@svr04:~# uname -i
Custom_hardware_platform
root@svr04:~# uname -a
Linux svr04 Custom_kernel_version Custom_kernel_build_string Custom_hardware_platform GNU/Linux
```
Response when config file entries are undefined:
```
root@svr04:~# uname -r
3.2.0-4-amd64
root@svr04:~# uname -i
x86_64
root@svr04:~# uname -a
Linux svr04 3.2.0-4-amd64 #1 SMP Debian 3.2.68-1+deb7u1 x86_64 GNU/Linux
```