### PR TITLE
command_tftp: fix exception

### DIFF
--- a/cowrie/core/artifact.py
+++ b/cowrie/core/artifact.py
@@ -43,6 +43,7 @@ class Artifact:
 
         self.fp = tempfile.NamedTemporaryFile(dir=self.artifactDir, delete=False)
         self.tempFilename = self.fp.name
+        self.closed = False
 
         self.shasum = ''
         self.shasumFilename = ''
@@ -78,6 +79,7 @@ class Artifact:
         self.fp.seek(0)
         data = self.fp.read()
         self.fp.close()
+        self.closed = True
         self.shasum = hashlib.sha256(data).hexdigest()
         self.shasumFilename = os.path.join(self.artifactDir, self.shasum)
 


### PR DESCRIPTION
    [!] Fix exception in tftpy library due to incorrect type of input parameter

Artifact:
    [+] Add property "closed"
