### PR TITLE
Add regex support to the userdb.

### DIFF
--- a/data/userdb.txt
+++ b/data/userdb.txt
@@ -1,5 +1,6 @@
 root:x:!root
 root:x:!123456
+root:x:!/honeypot/i
 root:x:*
 richard:x:*
 richard:x:fout


### PR DESCRIPTION
Fixes #762 

Regexes can be used both in the username and password parts, by placing a regex within a pair of slashes. To enable case insensitivity, use `i` at the end.

The `save()` method was removed from UserDB as it seems not to be in use anywhere, and there is no straightforward way to convert compiled regexes to their string representations.

As an example, to allow all users beginning with `nagios`, but except those having the word `honeypot` in their password, the following lines can be used:

```
/^nagios/:x:!/honeypot/i
/^nagios/:x:*
```
