### PR TITLE
Added Support for Elasticsearch Pipeline

### DIFF
--- a/cowrie.cfg.dist
+++ b/cowrie.cfg.dist
@@ -488,6 +488,7 @@ logfile = log/cowrie.json
 #port = 9200
 #index = cowrie
 #type = cowrie
+#pipeline = geoip
 
 
 # Send login attemp information to SANS DShield

--- a/cowrie/output/elasticsearch.py
+++ b/cowrie/output/elasticsearch.py
@@ -21,6 +21,7 @@ class Output(cowrie.core.output.Output):
         self.port = CONFIG.get('output_elasticsearch', 'port')
         self.index =CONFIG.get('output_elasticsearch', 'index')
         self.type = CONFIG.get('output_elasticsearch', 'type')
+        self.pipeline = CONFIG.get('output_elasticsearch', 'pipeline')
         cowrie.core.output.Output.__init__(self)
 
 
@@ -44,4 +45,4 @@ class Output(cowrie.core.output.Output):
             if i.startswith('log_'):
                 del logentry[i]
 
-        self.es.index(index=self.index, doc_type=self.type, body=logentry)
+        self.es.index(index=self.index, doc_type=self.type, body=logentry, pipeline=self.pipeline)


### PR DESCRIPTION
This adds support for [Ingest Plugins](https://www.elastic.co/guide/en/elasticsearch/plugins/current/ingest.html), specifically, the [Ingest Geoip Processor Plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/current/ingest-geoip.html), which means that by creating a Pipeline in Elasticsearch like:

```json
PUT _ingest/pipeline/geoip
{
  "description" : "Add geoip info",
  "processors" : [
    {
      "geoip" : {
        "field" : "src_ip"
      }
    }
  ]
}
```

Then, when posting to Elasticsearch and supplying the pipeline name of `geoip`, Elasticsearch would automatically resolve the `src_ip` field to the relevant location.