### PR TITLE
Clarify how to obtain version string in config

### DIFF
--- a/cowrie.cfg.dist
+++ b/cowrie.cfg.dist
@@ -319,6 +319,8 @@ dsa_private_key = ${honeypot:etc_path}/ssh_host_dsa_key
 # SSH Version String
 #
 # Use these to disguise your honeypot from a simple SSH version scan
+# You can connect to the SSH port using netcat to get the version string
+# nmap will not show the actual value
 # Examples:
 # SSH-2.0-OpenSSH_5.1p1 Debian-5
 # SSH-1.99-OpenSSH_4.3


### PR DESCRIPTION
I wondered why everything stopped working when I put in what nmap shows but it turns out that's already parsed. 