### PR TITLE
Bug Fix - output.py ignoring some eventids

### DIFF
--- a/cowrie/core/output.py
+++ b/cowrie/core/output.py
@@ -158,7 +158,7 @@ class Output(object):
             return
 
         # Ignore anything without session information
-        if 'sessionno' not in event and 'session' not in event:
+        if 'sessionno' not in event and 'session' not in event and 'system' not in event:
             return
 
         # Ignore anything without message


### PR DESCRIPTION
Bug Fix - fixing a bug that caused some eventids to be ignored by output.py.