### PR TITLE
Full docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY etc /src/etc
 COPY --from=builder /root/wheelhouse /root/wheelhouse
 RUN pip install -r requirements.txt --no-index --find-links=/root/wheelhouse && \
   mkdir /src/dl && \
-  mkdir -p /src/log && \
+  mkdir -p /src/log/tty && \
   mkdir /src/var
 
 FROM post-builder as linter
@@ -27,7 +27,7 @@ RUN pip install flake8 && \
 FROM post-builder as unittest
 ENV PYTHONPATH=/src
 WORKDIR /src
-RUN trial /src/cowrie
+RUN trial cowrie
 
 FROM post-builder
 ENV PYTHONPATH=/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM python:2-alpine3.8 as python-base
+MAINTAINER Florian Pelgrim <florian.pelgrim@craneworks.de>
+RUN apk add --no-cache libffi
+COPY requirements.txt .
+
+FROM python-base as builder
+RUN apk add --no-cache gcc musl-dev python-dev libffi-dev libressl-dev && \
+  pip wheel --wheel-dir=/root/wheelhouse -r requirements.txt
+
+FROM python-base as post-builder
+COPY src/ /src
+COPY data /src/data
+COPY honeyfs /src/honeyfs
+COPY share /src/share
+COPY etc /src/etc
+COPY --from=builder /root/wheelhouse /root/wheelhouse
+RUN pip install -r requirements.txt --no-index --find-links=/root/wheelhouse && \
+  mkdir /src/dl && \
+  mkdir -p /src/log && \
+  mkdir /src/var
+
+FROM post-builder as linter
+RUN pip install flake8 && \
+  rm -rf /root/wheelhouse && \
+  flake8 /src --count --select=E1,E2,E901,E999,F821,F822,F823 --show-source --statistics
+
+FROM post-builder as unittest
+ENV PYTHONPATH=/src
+WORKDIR /src
+RUN trial /src/cowrie
+
+FROM post-builder
+ENV PYTHONPATH=/src
+WORKDIR /src
+EXPOSE 2222/tcp
+CMD /usr/local/bin/python /usr/local/bin/twistd -u 65534 -g 65534 --umask 0022 --nodaemon --pidfile= -l - cowrie

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN trial cowrie
 
 FROM post-builder
 ENV PYTHONPATH=/src
+ENV COWRIE_DOCKER=0
 WORKDIR /src
 EXPOSE 2222/tcp
 CMD /usr/local/bin/python /usr/local/bin/twistd -u 65534 -g 65534 --umask 0022 --nodaemon --pidfile= -l - cowrie

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,30 @@
 FROM python:2-alpine3.8 as python-base
 MAINTAINER Florian Pelgrim <florian.pelgrim@craneworks.de>
-RUN apk add --no-cache libffi
+RUN apk add --no-cache libffi && \
+  addgroup -S cowrie && \
+  adduser -S -s /bin/bash -G cowrie -D -H -h /src cowrie && \
+  mkdir -p /src/dl && \
+  mkdir -p /src/log/tty && \
+  chown -R cowrie:cowrie /src && \
+  chmod -R 775 /src
 COPY requirements.txt .
+COPY data /src/data
+COPY honeyfs /src/honeyfs
+COPY share /src/share
+COPY etc /src/etc
 
 FROM python-base as builder
 RUN apk add --no-cache gcc musl-dev python-dev libffi-dev libressl-dev && \
   pip wheel --wheel-dir=/root/wheelhouse -r requirements.txt
 
 FROM python-base as post-builder
-COPY src/ /src
-COPY data /src/data
-COPY honeyfs /src/honeyfs
-COPY share /src/share
-COPY etc /src/etc
 COPY --from=builder /root/wheelhouse /root/wheelhouse
 RUN pip install -r requirements.txt --no-index --find-links=/root/wheelhouse && \
-  mkdir /src/dl && \
-  mkdir -p /src/log/tty && \
-  mkdir /src/var
+  rm -rf /root/wheelhouse
+COPY src /src
 
 FROM post-builder as linter
 RUN pip install flake8 && \
-  rm -rf /root/wheelhouse && \
   flake8 /src --count --select=E1,E2,E901,E999,F821,F822,F823 --show-source --statistics
 
 FROM post-builder as unittest
@@ -31,7 +34,8 @@ RUN trial cowrie
 
 FROM post-builder
 ENV PYTHONPATH=/src
-ENV COWRIE_DOCKER=0
 WORKDIR /src
 EXPOSE 2222/tcp
-CMD /usr/local/bin/python /usr/local/bin/twistd -u 65534 -g 65534 --umask 0022 --nodaemon --pidfile= -l - cowrie
+EXPOSE 2223/tcp
+USER cowrie
+CMD /usr/local/bin/python /usr/local/bin/twistd --umask 0022 --nodaemon --pidfile= -l - cowrie

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -115,7 +115,7 @@ Makes a Cowrie SSH/Telnet honeypot.
 """)
             sys.exit(1)
 
-        if os.name == 'posix' and os.getuid() == 0 and not os.getenv('COWRIE_DOCKER'):
+        if os.name == 'posix' and os.getuid() == 0:
             print('ERROR: You must not run cowrie as root!')
             sys.exit(1)
 

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -115,7 +115,7 @@ Makes a Cowrie SSH/Telnet honeypot.
 """)
             sys.exit(1)
 
-        if os.name == 'posix' and os.getuid() == 0:
+        if os.name == 'posix' and os.getuid() == 0 and not os.getenv('COWRIE_DOCKER'):
             print('ERROR: You must not run cowrie as root!')
             sys.exit(1)
 

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -115,10 +115,6 @@ Makes a Cowrie SSH/Telnet honeypot.
 """)
             sys.exit(1)
 
-        if os.name == 'posix' and os.getuid() == 0:
-            print('ERROR: You must not run cowrie as root!')
-            sys.exit(1)
-
         log.msg("Python Version {}".format(str(sys.version).replace('\n', '')))
         log.msg("Twisted Version {}.{}.{}".format(__version__.major, __version__.minor, __version__.micro))
 

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -115,6 +115,10 @@ Makes a Cowrie SSH/Telnet honeypot.
 """)
             sys.exit(1)
 
+        if os.name == 'posix' and os.getuid() == 0:
+            print('ERROR: You must not run cowrie as root!')
+            sys.exit(1)
+
         log.msg("Python Version {}".format(str(sys.version).replace('\n', '')))
         log.msg("Twisted Version {}.{}.{}".format(__version__.major, __version__.minor, __version__.micro))
 


### PR DESCRIPTION
Currently Docker images are build by a second git repository.
Changes to installation or starting cowrie would need to be done on
both. Merging this into one repository prevents that those will be
forgotten and makes it easier to understand why changes happen.

The dockerfile is a different one then the one from the docker-cworie
repository.
I choosed to use a python2-alpine linux. In the end this image has 55%
smaller image size than the Debian image. The build process is splitted
into to parts. The first image has everythign installed to compile the
python modules. The second one has only things installed which are
needed to run the daemon.
There is no need to install python-virtualenv because we are using
docker. We don't need that much layers.
Twisted can drop his privileges when starting the daemon when `--uid`
and `--gid` is passed. This works only with numerical id. The user
nobody is used for this. This is on Docker a good idea since there
should be only one service with this user running. In other systems
there might be several services using this daemon which is not a good
choise.

When building a new Docker image for cowrie Docker multistage build
images are created running flake8 and unittests to ensure that all
future releases are stable and matching our code guidelines.

Bonus effect is when using this as a git pre-push-hook a developer
doesn't need to wait for travis to fail on an error.

Based on the current project structure we need a lot of `COPY`
instructions inside the dockerfile which has negative sideeffects.
- bloading the dockerfile up
- longer buildtimes
- more layers are created
- more diskspace is used

We should find a way to reduce this. Best way for doing this is keeping
the static files like `honeyfs` and `share` right next to the source
code.