### PR TITLE
Optimize imports, removed pseudo docstrings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY src /cowrie
 
 FROM post-builder as linter
 RUN pip install flake8 && \
-  flake8 /cowrie --count --select=E1,E2,E3,E901,E999,F821,F822,F823 --show-source --statistics
+  flake8 /cowrie --count --select=E1,E2,E3,E901,E999,F401,F821,F822,F823 --show-source --statistics
 
 FROM post-builder as unittest
 ENV PYTHONPATH=/cowrie

--- a/bin/asciinema
+++ b/bin/asciinema
@@ -14,7 +14,6 @@ COLOR_INPUT = '\033[33m'
 COLOR_RESET = '\033[0m'
 
 def playlog(fd, settings):
-
     thelog = {}
     thelog['version'] = 1
     thelog['width'] = 80
@@ -88,7 +87,6 @@ def playlog(fd, settings):
 
 
 def help(verbose=False):
-
     print(( 'usage: %s [-c] [-o output] <tty-log-file> <tty-log-file>...' % \
         os.path.basename(sys.argv[0])))
 
@@ -99,7 +97,6 @@ def help(verbose=False):
 
 
 if __name__ == '__main__':
-
     settings = {
         'colorify':     0,
         'output': ""

--- a/bin/createdynamicprocess.py
+++ b/bin/createdynamicprocess.py
@@ -1,7 +1,8 @@
-import psutil
 import json
 import datetime
 import random
+
+import psutil
 
 command = {}
 command['command'] = {}

--- a/bin/createfs
+++ b/bin/createfs
@@ -8,9 +8,12 @@
 #
 ##############################################################
 
-import os, pickle, sys, locale, getopt, fnmatch
+import fnmatch
+import getopt
+import os
+import pickle
+import sys
 from stat import *
-
 
 A_NAME, A_TYPE, A_UID, A_GID, A_SIZE, A_MODE, \
     A_CTIME, A_CONTENTS, A_TARGET, A_REALFILE = range(0, 10)

--- a/bin/fsctl
+++ b/bin/fsctl
@@ -18,7 +18,12 @@
 # March 2013
 ################################################################
 
-import os, pickle, sys, locale, time, cmd, copy
+import cmd
+import copy
+import os
+import pickle
+import sys
+import time
 from stat import *
 
 A_NAME, A_TYPE, A_UID, A_GID, A_SIZE, A_MODE, \
@@ -51,7 +56,13 @@ def exists(fs, path):
             raise Exception(e)
 
 def is_directory(fs,path):
-    "Returns whether or not the file at 'path' is a directory"
+    """
+    Returns whether or not the file at 'path' is a directory
+
+    :param fs:
+    :param path:
+    :return:
+    """
     file = getpath(fs,path)
     if file[A_TYPE] == T_DIR:
         return True
@@ -59,8 +70,9 @@ def is_directory(fs,path):
         return False
 
 def resolve_reference(pwd, relativeReference):
-    '''Used to resolve a current working directory and a relative
-      reference into an absolute file reference.'''
+    """
+    Used to resolve a current working directory and a relative reference into an absolute file reference.
+    """
 
     tempPath = os.path.join(pwd, relativeReference)
     absoluteReference = os.path.normpath(tempPath)
@@ -103,7 +115,10 @@ class fseditCmd(cmd.Cmd):
             "Type 'help' for help\n"
 
     def save_pickle(self):
-        '''saves the current file system to the pickle'''
+        """
+        saves the current file system to the pickle
+        :return:
+        """
         try:
             pickle.dump(self.fs, open(self.pickle_file_path, 'wb'))
         except Exception as e:
@@ -114,19 +129,25 @@ class fseditCmd(cmd.Cmd):
             sys.exit(1)
 
     def do_exit(self, args):
-        '''Exits the file system editor'''
+        """
+        Exits the file system editor
+        """
         return True
 
     def do_EOF(self, args):
-        '''The escape character ctrl+d exits the session'''
+        """
+        The escape character ctrl+d exits the session
+        """
         #exiting from the do_EOF method does not create a newline automatically
         #so we add it manually
         print()
         return True
 
     def do_ls(self, args):
-        '''Prints the contents of a directory, use ls -l to list in long format
-        Prints the current directory if no arguments are specified'''
+        """
+        Prints the contents of a directory, use ls -l to list in long format
+        Prints the current directory if no arguments are specified
+        """
 
         longls = False
 
@@ -214,7 +235,9 @@ class fseditCmd(cmd.Cmd):
         self.prompt = self.fs_name + ":" + self.pwd + "$ "
 
     def do_cd(self, args):
-        '''Changes the current directory.\nUsage: cd <target directory>'''
+        """
+        Changes the current directory.\nUsage: cd <target directory>
+        """
 
         #count  the number of arguments
         # 1 or more arguments: changes the directory to the first arg
@@ -236,13 +259,20 @@ class fseditCmd(cmd.Cmd):
                 print(("cd: %s: Not a directory" % target_dir))
 
     def do_pwd(self, args):
-        '''Prints the current working directory'''
+        """
+        Prints the current working directory
+
+        :param args:
+        :return:
+        """
         print((self.pwd))
 
     def do_mkdir(self, args):
-        """Add a new directory in the target directory.
+        """
+        Add a new directory in the target directory.
         Handles relative or absolute file paths. \n
-        Usage: mkdir <destination>..."""
+        Usage: mkdir <destination>...
+        """
 
         arg_list=args.split()
         if len(arg_list) < 1:
@@ -252,9 +282,11 @@ class fseditCmd(cmd.Cmd):
                 self.mkfile(arg.split(), T_DIR)
 
     def do_touch(self, args):
-        """Add a new file in the target directory.
+        """
+        Add a new file in the target directory.
         Handles relative or absolute file paths. \n
-        Usage: touch <destination> [<size in bytes>]"""
+        Usage: touch <destination> [<size in bytes>]
+        """
 
         arg_list=args.split()
 
@@ -264,7 +296,9 @@ class fseditCmd(cmd.Cmd):
             self.mkfile(arg_list, T_FILE)
 
     def mkfile(self, args, file_type):
-        '''args must be a list of arguments'''
+        """
+        args must be a list of arguments
+        """
         cwd = self.fs
         path = resolve_reference(self.pwd, args[0])
         pathList = path.split('/')
@@ -304,9 +338,11 @@ class fseditCmd(cmd.Cmd):
         print(("Added '%s'" % path))
 
     def do_rm(self, arguments):
-        '''Remove an object from the file system.
+        """
+        Remove an object from the file system.
         Will not remove a directory unless the -r switch is invoked.\n
-        Usage: rm [-r] <target>'''
+        Usage: rm [-r] <target>
+        """
 
         args = arguments.split()
 
@@ -347,10 +383,12 @@ class fseditCmd(cmd.Cmd):
         print(("Deleted %s" % target_path))
 
     def do_rmdir(self, arguments):
-        '''Remove a file object. Like the unix command,
+        """
+        Remove a file object. Like the unix command,
         this can only delete empty directories.
         Use rm -r to recursively delete full directories.\n
-        Usage: rmdir <target directory>'''
+        Usage: rmdir <target directory>
+        """
         args = arguments.split()
 
         if len(args) != 1:
@@ -390,8 +428,10 @@ class fseditCmd(cmd.Cmd):
         print(("Deleted %s" % target_path))
 
     def do_mv(self, arguments):
-        '''Moves a file/directory from one directory to another.\n
-        Usage: mv <source file> <destination file>'''
+        """
+        Moves a file/directory from one directory to another.\n
+        Usage: mv <source file> <destination file>
+        """
         args = arguments.split()
         if len(args) != 2:
             print('Usage: mv <source> <destination>')
@@ -450,8 +490,10 @@ class fseditCmd(cmd.Cmd):
         print(('File moved from /%s to /%s' % (src, dst)))
 
     def do_cp(self, arguments):
-        '''Copies a file/directory from one directory to another.\n
-        Usage: cp <source file> <destination file>'''
+        """
+        Copies a file/directory from one directory to another.\n
+        Usage: cp <source file> <destination file>
+        """
         args = arguments.split()
         if len(args) != 2:
             print('Usage: cp <source> <destination>')
@@ -504,7 +546,9 @@ class fseditCmd(cmd.Cmd):
         print(('File copied from /%s to /%s/%s' % (src, dstparent, dstname)))
 
     def do_chown(self, args):
-        '''Change file ownership'''
+        """
+        Change file ownership
+        """
         arg_list = args.split()
 
         if len(arg_list) != 2:
@@ -525,7 +569,9 @@ class fseditCmd(cmd.Cmd):
         self.save_pickle()
 
     def do_chgrp(self, args):
-        '''Change file ownership'''
+        """
+        Change file ownership
+        """
         arg_list = args.split()
 
         if len(arg_list) != 2:
@@ -546,8 +592,10 @@ class fseditCmd(cmd.Cmd):
         self.save_pickle()
 
     def do_chmod(self, args):
-        '''Change file permissions
-        only modes between 000 and 777 are implemented'''
+        """
+        Change file permissions
+        only modes between 000 and 777 are implemented
+        """
 
         arg_list = args.split()
 
@@ -583,7 +631,9 @@ class fseditCmd(cmd.Cmd):
         self.save_pickle()
 
     def do_file(self, args):
-        '''Identifies file types.\nUsage: file <file name>'''
+        """
+        Identifies file types.\nUsage: file <file name>
+        """
         arg_list = args.split()
 
         if len(arg_list) != 1:
@@ -620,13 +670,17 @@ class fseditCmd(cmd.Cmd):
         print(target_path+" is a "+msg)
 
     def do_clear(self, args):
-        '''Clears the screen'''
+        """
+        Clears the screen
+        """
         os.system('clear')
 
     def emptyline(self):
-        '''By default the cmd object will repeat the last command
+        """
+        By default the cmd object will repeat the last command
         if a blank line is entered. Since this is different than
-        bash behavior, overriding this method will stop it.'''
+        bash behavior, overriding this method will stop it.
+        """
         pass
 
     def help_help(self):

--- a/bin/playlog
+++ b/bin/playlog
@@ -3,13 +3,16 @@
 # Copyright (C) 2003-2011 Upi Tamminen <desaster@dragonlight.fi>
 #
 
-import os, sys, time, struct, string, getopt
+import getopt
+import os
+import struct
+import sys
+import time
 
 OP_OPEN, OP_CLOSE, OP_WRITE, OP_EXEC = 1, 2, 3, 4
 TYPE_INPUT, TYPE_OUTPUT, TYPE_INTERACT = 1, 2, 3
 
 def playlog(fd, settings):
-
     ssize = struct.calcsize('<iLiiLL')
     currtty, prevtime, prefdir = 0, 0, 0
 
@@ -67,7 +70,6 @@ def playlog(fd, settings):
             break
 
 def help(brief = 0):
-
     print('Usage: %s [-bfhi] [-m secs] [-w file] <tty-log-file> <tty-log-file>...\n' % \
         os.path.basename(sys.argv[0]))
 

--- a/src/cowrie/commands/adduser.py
+++ b/src/cowrie/commands/adduser.py
@@ -9,18 +9,14 @@ from twisted.internet import reactor
 
 from cowrie.shell.command import HoneyPotCommand
 
-
 commands = {}
 
 O_O, O_Q, O_P = 1, 2, 3
 
 
 class command_adduser(HoneyPotCommand):
-    """
-    """
+
     def start(self):
-        """
-        """
         self.username = None
         self.item = 0
         for arg in self.args:
@@ -64,8 +60,6 @@ class command_adduser(HoneyPotCommand):
         self.do_output()
 
     def do_output(self):
-        """
-        """
         if self.item == len(self.output):
             self.item = 7
             self.schedule_next()
@@ -83,14 +77,10 @@ class command_adduser(HoneyPotCommand):
             self.schedule_next()
 
     def schedule_next(self):
-        """
-        """
         self.scheduled = reactor.callLater(
             0.5 + random.random() * 1, self.do_output)
 
     def lineReceived(self, line):
-        """
-        """
         if self.item + 1 == len(self.output) and line.strip() in ('n', 'no'):
             self.exit()
             return

--- a/src/cowrie/commands/apt.py
+++ b/src/cowrie/commands/apt.py
@@ -11,7 +11,6 @@ from twisted.internet.defer import inlineCallbacks
 
 from cowrie.shell.command import HoneyPotCommand
 
-
 commands = {}
 
 

--- a/src/cowrie/commands/base64.py
+++ b/src/cowrie/commands/base64.py
@@ -15,9 +15,6 @@ class command_base64(HoneyPotCommand):
     """
 
     def start(self):
-        """
-        """
-
         self.mode = 'e'
         self.ignore = False
 

--- a/src/cowrie/commands/busybox.py
+++ b/src/cowrie/commands/busybox.py
@@ -1,11 +1,11 @@
-"""
-"""
+
 
 from __future__ import division, absolute_import
 
+from twisted.python import log
+
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.honeypot import StdOutStdErrEmulationProtocol
-from twisted.python import log
 
 commands = {}
 
@@ -58,14 +58,10 @@ class command_busybox(HoneyPotCommand):
     """
 
     def help(self):
-        """
-        """
         for ln in busybox_help:
             self.errorWrite('{0}\n'.format(ln))
 
     def call(self):
-        """
-        """
         if len(self.args) == 0:
             self.help()
             return

--- a/src/cowrie/commands/cat.py
+++ b/src/cowrie/commands/cat.py
@@ -28,8 +28,6 @@ class command_cat(HoneyPotCommand):
     linenumber = 1
 
     def start(self):
-        """
-        """
         try:
             optlist, args = getopt.gnu_getopt(self.args, 'AbeEnstTuv', ['help', 'number', 'version'])
         except getopt.GetoptError as err:
@@ -96,8 +94,6 @@ class command_cat(HoneyPotCommand):
         self.exit()
 
     def help(self):
-        """
-        """
         self.write(
             """Usage: cat [OPTION]... [FILE]...
             Concatenate FILE(s) to standard output.

--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -3,33 +3,26 @@
 
 from __future__ import division, absolute_import
 
-import time
-import re
-import os
 import getopt
 import hashlib
-from OpenSSL import SSL
+import os
+import re
+import time
 
-from twisted.web import client
+from OpenSSL import SSL
 from twisted.internet import reactor, ssl
 from twisted.python import log, compat
-
-from cowrie.shell.command import HoneyPotCommand
+from twisted.web import client
 
 from cowrie.core.config import CONFIG
-
-"""
-"""
+from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
 
 
 class command_curl(HoneyPotCommand):
-    """
-    """
+
     def start(self):
-        """
-        """
         try:
             optlist, args = getopt.getopt(self.args, 'sho:O', ['help', 'manual', 'silent'])
         except getopt.GetoptError as err:
@@ -101,9 +94,6 @@ class command_curl(HoneyPotCommand):
             self.deferred.addErrback(self.error, url)
 
     def curl_help(self):
-        """
-        """
-
         self.write("""Usage: curl [options...] <url>
 Options: (H) means HTTP/HTTPS only, (F) means FTP only
      --anyauth       Pick "any" authentication method (H)
@@ -261,8 +251,6 @@ Options: (H) means HTTP/HTTPS only, (F) means FTP only
         self.exit()
 
     def download(self, url, fakeoutfile, outputfile, *args, **kwargs):
-        """
-        """
         try:
             parsed = compat.urllib_parse.urlparse(url)
             scheme = parsed.scheme
@@ -293,14 +281,10 @@ Options: (H) means HTTP/HTTPS only, (F) means FTP only
         return factory.deferred
 
     def handle_CTRL_C(self):
-        """
-        """
         self.write('^C\n')
         self.connection.transport.loseConnection()
 
     def success(self, data, outfile):
-        """
-        """
         if not os.path.isfile(self.safeoutfile):
             log.msg("there's no file " + self.safeoutfile)
             self.exit()
@@ -336,8 +320,7 @@ Options: (H) means HTTP/HTTPS only, (F) means FTP only
         self.exit()
 
     def error(self, error, url):
-        """
-        """
+
         if hasattr(error, 'getErrorMessage'):  # Exceptions
             error = error.getErrorMessage()
         self.write('{0}\n'.format(error))
@@ -356,8 +339,6 @@ class HTTPProgressDownloader(client.HTTPDownloader):
     lastupdate = 0
 
     def __init__(self, curl, fakeoutfile, url, outfile, headers=None):
-        """
-        """
         client.HTTPDownloader.__init__(self, url, outfile, headers=headers, agent=b'curl/7.38.0')
         self.status = None
         self.curl = curl
@@ -376,8 +357,6 @@ class HTTPProgressDownloader(client.HTTPDownloader):
             client.HTTPDownloader.noPage(self, reason)
 
     def gotHeaders(self, headers):
-        """
-        """
         if self.status == b'200':
             if b'content-length' in headers:
                 self.totallength = int(headers[b'content-length'][0].decode())
@@ -402,8 +381,6 @@ class HTTPProgressDownloader(client.HTTPDownloader):
         return client.HTTPDownloader.gotHeaders(self, headers)
 
     def pagePart(self, data):
-        """
-        """
         if self.status == b'200':
             self.currentlength += len(data)
 
@@ -429,8 +406,6 @@ class HTTPProgressDownloader(client.HTTPDownloader):
         return client.HTTPDownloader.pagePart(self, data)
 
     def pageEnd(self):
-        """
-        """
         if self.totallength != 0 and self.currentlength != self.totallength:
             return client.HTTPDownloader.pageEnd(self)
 

--- a/src/cowrie/commands/env.py
+++ b/src/cowrie/commands/env.py
@@ -8,9 +8,7 @@ commands = {}
 """
 env: invalid option -- 'h'
 Try `env --help' for more information.
-"""
 
-"""
 Usage: env [OPTION]... [-] [NAME=VALUE]... [COMMAND [ARG]...]
 Set each NAME to VALUE in the environment and run COMMAND.
 
@@ -30,11 +28,8 @@ For complete documentation, run: info coreutils 'env invocation'
 
 
 class command_env(HoneyPotCommand):
-    """
-    """
+
     def call(self):
-        """
-        """
         for i in list(self.environ.keys()):
             self.write(b'{0}={1}\n'.format(i, self.environ[i]))
 

--- a/src/cowrie/commands/ethtool.py
+++ b/src/cowrie/commands/ethtool.py
@@ -10,12 +10,8 @@ commands = {}
 
 
 class command_ethtool(HoneyPotCommand):
-    """
-    """
 
     def call(self):
-        """
-        """
         func = self.do_ethtool_help
         for x in self.args:
             if x.startswith('lo'):
@@ -34,14 +30,11 @@ class command_ethtool(HoneyPotCommand):
 For more information run ethtool -h\n""")
 
     def do_ethtool_lo(self):
-        """
-        """
+
         self.write("""Settings for lo:
             Link detected: yes\n""")
 
     def do_ethtool_eth0(self):
-        """
-        """
         self.write("""Settings for eth0:
 Supported ports: [ TP MII ]
 Supported link modes:   10baseT/Half 10baseT/Full
@@ -72,8 +65,6 @@ Current message level: 0x00000033 (51)
 Link detected: yes\n""")
 
     def do_ethtool_eth1(self):
-        """
-        """
         self.write("""Settings for eth1:
 Cannot get device settings: No such device
 Cannot get wake-on-lan settings: No such device

--- a/src/cowrie/commands/free.py
+++ b/src/cowrie/commands/free.py
@@ -34,8 +34,6 @@ class command_free(HoneyPotCommand):
     free
     """
     def call(self):
-        """
-        """
         # Parse options or display no files
         try:
             opts, args = getopt.getopt(self.args, 'mh')

--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -8,15 +8,15 @@ Filesystem related commands
 
 from __future__ import division, absolute_import
 
-import re
-import getopt
 import copy
+import getopt
 import os.path
+import re
 
 from twisted.python import log
 
-from cowrie.shell.command import HoneyPotCommand
 import cowrie.shell.fs as fs
+from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
 
@@ -100,7 +100,6 @@ class command_tail(HoneyPotCommand):
     """
 
     def tail_get_contents(self, filename):
-
         try:
             contents = self.fs.file_contents(filename)
             self.tail_application(contents)

--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -3,17 +3,16 @@
 
 from __future__ import division, absolute_import
 
-import os
-import getopt
-import socket
 import ftplib
+import getopt
+import os
+import socket
 
 from twisted.python import log
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CONFIG
 from cowrie.shell.command import HoneyPotCommand
-
 
 commands = {}
 
@@ -78,8 +77,7 @@ class FTP(ftplib.FTP):
 
 
 class command_ftpget(HoneyPotCommand):
-    """
-    """
+
     def help(self):
         self.write("""BusyBox v1.20.2 (2016-06-22 15:12:53 EDT) multi-call binary.
 
@@ -195,7 +193,6 @@ Download a file via FTP
         self.exit()
 
     def ftp_download(self):
-
         out_addr = ('', 0)
         if CONFIG.has_option('honeypot', 'out_addr'):
             out_addr = (CONFIG.get('honeypot', 'out_addr'), 0)

--- a/src/cowrie/commands/gcc.py
+++ b/src/cowrie/commands/gcc.py
@@ -2,17 +2,16 @@
 
 from __future__ import division, absolute_import
 
-import time
-import re
 import getopt
-import random
 import os
+import random
+import re
+import time
 
 from twisted.internet import reactor
 
-from cowrie.shell.command import HoneyPotCommand
-
 from cowrie.core.config import CONFIG
+from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
 
@@ -130,19 +129,25 @@ class command_gcc(HoneyPotCommand):
             self.no_files()
 
     def handle_CTRL_C(self):
-        """ Make sure the scheduled call will be canceled """
+        """
+        Make sure the scheduled call will be canceled
+        """
 
         if getattr(self, 'scheduled', False):
             self.scheduled.cancel()
 
     def no_files(self):
-        """ Notify user there are no input files, and exit """
+        """
+        Notify user there are no input files, and exit
+        """
         self.write("""gcc: fatal error: no input files
 compilation terminated.\n""")
         self.exit()
 
     def version(self, short):
-        """ Print long or short version, and exit """
+        """
+        Print long or short version, and exit
+        """
 
         # Generate version number
         version = '.'.join([str(v) for v in command_gcc.APP_VERSION[:3]])
@@ -207,12 +212,16 @@ gcc version %s (Debian %s-5)""" % (version, version_short, version_short, versio
         self.exit()
 
     def arg_missing(self, arg):
-        """ Print missing argument message, and exit """
+        """
+        Print missing argument message, and exit
+        """
         self.write("%s: argument to '%s' is missing\n" % (command_gcc.APP_NAME, arg))
         self.exit()
 
     def help(self):
-        """ Print help info, and exit """
+        """
+        Print help info, and exit
+        """
 
         version = '.'.join([str(v) for v in command_gcc.APP_VERSION[:2]])
 

--- a/src/cowrie/commands/ifconfig.py
+++ b/src/cowrie/commands/ifconfig.py
@@ -4,8 +4,9 @@
 
 from __future__ import division, absolute_import
 
-from cowrie.shell.command import HoneyPotCommand
 from random import randrange, randint
+
+from cowrie.shell.command import HoneyPotCommand
 
 HWaddr = "%02x:%02x:%02x:%02x:%02x:%02x" % (randint(0, 255), randint(0, 255), randint(0, 255), randint(0, 255), randint(0, 255), randint(0, 255))
 

--- a/src/cowrie/commands/iptables.py
+++ b/src/cowrie/commands/iptables.py
@@ -226,12 +226,16 @@ Perhaps iptables or your kernel needs to be upgraded.\n""" % (command_iptables.A
         return True
 
     def show_version(self):
-        """ Show version and exit """
+        """
+        Show version and exit
+        """
         self.write('%s %s\n' % (command_iptables.APP_NAME, command_iptables.APP_VERSION))
         self.exit()
 
     def show_help(self):
-        """ Show help and exit """
+        """
+        Show help and exit
+        """
 
         self.write("""%s %s'
 
@@ -299,7 +303,9 @@ Options:
         self.exit()
 
     def list_rules(self, chain):
-        """ List current rules as commands"""
+        """
+        List current rules as commands
+        """
 
         if self.user_is_root():
             if len(chain) > 0:
@@ -364,7 +370,9 @@ Options:
             self.no_permission()
 
     def flush(self, chain):
-        """ Mark rules as flushed """
+        """
+        Mark rules as flushed
+        """
 
         if self.user_is_root():
             if len(chain) > 0:

--- a/src/cowrie/commands/ls.py
+++ b/src/cowrie/commands/ls.py
@@ -3,40 +3,32 @@
 
 from __future__ import division, absolute_import
 
-import stat
 import getopt
+import stat
 import time
 
-from cowrie.shell.command import HoneyPotCommand
 import cowrie.shell.fs as fs
+from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.pwd import Passwd, Group
 
 commands = {}
 
 
 class command_ls(HoneyPotCommand):
-    """
-    """
 
     def uid2name(self, uid):
-        """
-        """
         try:
             return Passwd().getpwuid(uid)["pw_name"]
         except:
             return str(uid)
 
     def gid2name(self, gid):
-        """
-        """
         try:
             return Group().getgrgid(gid)["gr_name"]
         except:
             return str(gid)
 
     def call(self):
-        """
-        """
         path = self.protocol.cwd
         paths = []
         self.showHidden = False
@@ -69,8 +61,6 @@ class command_ls(HoneyPotCommand):
                 func(path)
 
     def do_ls_normal(self, path):
-        """
-        """
         try:
             if self.protocol.fs.isdir(path) and self.showDirectories == False:
                 files = self.protocol.fs.get_path(path)[:]
@@ -113,8 +103,6 @@ class command_ls(HoneyPotCommand):
         self.write('\n')
 
     def do_ls_l(self, path):
-        """
-        """
         try:
             if self.protocol.fs.isdir(path) and self.showDirectories == False:
                 files = self.protocol.fs.get_path(path)[:]

--- a/src/cowrie/commands/nc.py
+++ b/src/cowrie/commands/nc.py
@@ -6,9 +6,8 @@ import socket
 import struct
 import sys
 
-from cowrie.shell.command import HoneyPotCommand
-
 from cowrie.core.config import CONFIG
+from cowrie.shell.command import HoneyPotCommand
 
 if sys.version_info > (3,):
     long = int
@@ -17,22 +16,30 @@ commands = {}
 
 
 def makeMask(n):
-    """return a mask of n bits as a long integer"""
+    """
+    return a mask of n bits as a long integer
+    """
     return (long(2) << n - 1) - 1
 
 
 def dottedQuadToNum(ip):
-    """convert decimal dotted quad string to long integer"""
+    """
+    convert decimal dotted quad string to long integer
+    """
     return struct.unpack('I', socket.inet_aton(ip))[0]
 
 
 def networkMask(ip, bits):
-    """Convert a network address to a long integer"""
+    """
+    Convert a network address to a long integer
+    """
     return dottedQuadToNum(ip) & makeMask(bits)
 
 
 def addressInNetwork(ip, net):
-    """Is an address in a network"""
+    """
+    Is an address in a network
+    """
     return ip & net == net
 
 
@@ -41,8 +48,6 @@ local_networks = [networkMask('10.0.0.0', 8), networkMask('172.16.0.0', 12), net
 
 class command_nc(HoneyPotCommand):
     def help(self):
-        """
-        """
         self.write(
             """This is nc from the netcat-openbsd package. An alternative nc is available
 in the netcat-traditional package.
@@ -52,9 +57,6 @@ usage: nc [-46bCDdhjklnrStUuvZz] [-I length] [-i interval] [-O length]
           [-x proxy_address[:port]] [destination] [port]\n""")
 
     def start(self):
-        """
-        """
-
         try:
             optlist, args = getopt.getopt(self.args, '46bCDdhklnrStUuvZzI:i:O:P:p:q:s:T:V:w:X:x:')
         except getopt.GetoptError as err:
@@ -94,9 +96,7 @@ usage: nc [-46bCDdhjklnrStUuvZz] [-I length] [-i interval] [-O length]
         self.recv_data()
 
     def recv_data(self):
-
         data = ''
-
         while 1:
             packet = self.s.recv(1024)
             if packet == '':
@@ -109,18 +109,15 @@ usage: nc [-46bCDdhjklnrStUuvZz] [-I length] [-i interval] [-O length]
         self.exit()
 
     def lineReceived(self, line):
-
         if hasattr(self, 's'):
             self.s.send(line)
 
     def handle_CTRL_C(self):
-
         self.write('^C\n')
         if hasattr(self, 's'):
             self.s.close()
 
     def handle_CTRL_D(self):
-
         if hasattr(self, 's'):
             self.s.close()
 

--- a/src/cowrie/commands/perl.py
+++ b/src/cowrie/commands/perl.py
@@ -17,8 +17,7 @@ commands = {}
 
 
 class command_perl(HoneyPotCommand):
-    """
-    """
+
     def version(self):
         output = (
             '',
@@ -75,8 +74,6 @@ class command_perl(HoneyPotCommand):
             self.write(l + '\n')
 
     def start(self):
-        """
-        """
         try:
             opts, args = getopt.gnu_getopt(self.args, 'acfhnpsStTuUvwWXC:D:e:E:F:i:I:l:m:M:V:X:')
         except getopt.GetoptError as err:
@@ -107,16 +104,12 @@ class command_perl(HoneyPotCommand):
             pass
 
     def lineReceived(self, line):
-        """
-        """
         log.msg(eventid='cowrie.command.input',
                 realm='perl',
                 input=line,
                 format='INPUT (%(realm)s): %(input)s')
 
     def handle_CTRL_D(self):
-        """
-        """
         self.exit()
 
 

--- a/src/cowrie/commands/ping.py
+++ b/src/cowrie/commands/ping.py
@@ -3,11 +3,11 @@
 
 from __future__ import division, absolute_import
 
-import re
-import random
-import hashlib
-import socket
 import getopt
+import hashlib
+import random
+import re
+import socket
 
 from twisted.internet import reactor
 
@@ -17,12 +17,8 @@ commands = {}
 
 
 class command_ping(HoneyPotCommand):
-    """
-    """
 
     def valid_ip(self, address):
-        """
-        """
         try:
             socket.inet_aton(address)
             return True
@@ -30,8 +26,6 @@ class command_ping(HoneyPotCommand):
             return False
 
     def start(self):
-        """
-        """
         self.host = None
         self.max = 0
         self.running = False
@@ -82,8 +76,6 @@ class command_ping(HoneyPotCommand):
         self.count = 0
 
     def showreply(self):
-        """
-        """
         ms = 40 + random.random() * 10
         self.write(
             '64 bytes from %s (%s): icmp_seq=%d ttl=50 time=%.1f ms\n' % \
@@ -98,15 +90,11 @@ class command_ping(HoneyPotCommand):
             self.scheduled = reactor.callLater(1, self.showreply)
 
     def printstatistics(self):
-        """
-        """
         self.write('--- %s ping statistics ---\n' % (self.host,))
         self.write('%d packets transmitted, %d received, 0%% packet loss, time 907ms\n' % (self.count, self.count))
         self.write('rtt min/avg/max/mdev = 48.264/50.352/52.441/2.100 ms\n')
 
     def handle_CTRL_C(self):
-        """
-        """
         if self.running is False:
             return HoneyPotCommand.handle_CTRL_C(self)
         else:

--- a/src/cowrie/commands/python.py
+++ b/src/cowrie/commands/python.py
@@ -17,8 +17,7 @@ commands = {}
 
 
 class command_python(HoneyPotCommand):
-    """
-    """
+
     def version(self):
         ver = 'Python 2.7.11+'
         self.write(ver + '\n')
@@ -74,8 +73,6 @@ class command_python(HoneyPotCommand):
             self.write(l + '\n')
 
     def start(self):
-        """
-        """
         try:
             opts, args = getopt.gnu_getopt(self.args, 'BdEhiORsStuvVx3c:m:Q:W:', ['help', 'version'])
         except getopt.GetoptError as err:
@@ -118,16 +115,12 @@ class command_python(HoneyPotCommand):
             pass
 
     def lineReceived(self, line):
-        """
-        """
         log.msg(eventid='cowrie.command.input',
                 realm='python',
                 input=line,
                 format='INPUT (%(realm)s): %(input)s')
 
     def handle_CTRL_D(self):
-        """
-        """
         self.exit()
 
 

--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -29,36 +29,29 @@
 from __future__ import division, absolute_import
 
 import getopt
+import hashlib
 import os
 import re
-import hashlib
 import time
 
 from twisted.python import log
 
-from cowrie.shell.command import HoneyPotCommand
-from cowrie.shell import fs
-
 from cowrie.core.config import CONFIG
+from cowrie.shell import fs
+from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
 
 
 class command_scp(HoneyPotCommand):
-    """
-    """
 
     def help(self):
-        """
-        """
         self.write(
             """usage: scp [-12346BCpqrv] [-c cipher] [-F ssh_config] [-i identity_file]
            [-l limit] [-o ssh_option] [-P port] [-S program]
            [[user@]host1:]file1 ... [[user@]host2:]file2\n""")
 
     def start(self):
-        """
-        """
         self.download_path = CONFIG.get('honeypot', 'download_path')
 
         try:
@@ -81,7 +74,6 @@ class command_scp(HoneyPotCommand):
                 break
 
         if self.out_dir:
-
             outdir = self.fs.resolve_path(self.out_dir, self.protocol.cwd)
 
             if not self.fs.exists(outdir):
@@ -100,8 +92,6 @@ class command_scp(HoneyPotCommand):
         self.write('\x00')
 
     def lineReceived(self, line):
-        """
-        """
         log.msg(eventid='cowrie.session.file_download',
                 realm='scp',
                 input=line,
@@ -109,7 +99,6 @@ class command_scp(HoneyPotCommand):
         self.protocol.terminal.write('\x00')
 
     def drop_tmp_file(self, data, name):
-
         tmp_fname = '%s-%s-%s-scp_%s' % \
                     (time.strftime('%Y%m%d-%H%M%S'),
                      self.protocol.getProtoTransport().transportId,
@@ -122,7 +111,6 @@ class command_scp(HoneyPotCommand):
             f.write(data)
 
     def save_file(self, data, fname):
-
         self.drop_tmp_file(data, fname)
 
         if os.path.exists(self.safeoutfile):
@@ -152,7 +140,6 @@ class command_scp(HoneyPotCommand):
             self.fs.chown(fname, self.protocol.user.uid, self.protocol.user.gid)
 
     def parse_scp_data(self, data):
-
         # scp data format:
         # C0XXX filesize filename\nfile_data\x00
         # 0XXX - file permissions
@@ -203,7 +190,6 @@ class command_scp(HoneyPotCommand):
         return data
 
     def handle_CTRL_D(self):
-
         if self.protocol.terminal.stdinlogOpen and self.protocol.terminal.stdinlogFile and \
                 os.path.exists(self.protocol.terminal.stdinlogFile):
             with open(self.protocol.terminal.stdinlogFile, 'rb') as f:
@@ -221,7 +207,6 @@ class command_scp(HoneyPotCommand):
         self.exit()
 
     def handle_CTRL_D(self):
-
         if self.protocol.terminal.stdinlogOpen and self.protocol.terminal.stdinlogFile and \
                 os.path.exists(self.protocol.terminal.stdinlogFile):
             with open(self.protocol.terminal.stdinlogFile, 'rb') as f:

--- a/src/cowrie/commands/service.py
+++ b/src/cowrie/commands/service.py
@@ -85,14 +85,10 @@ class command_service(HoneyPotCommand):
             self.write(l + '\n')
 
     def help(self):
-        """
-        """
         output = 'Usage: service < option > | --status-all | [ service_name [ command | --full-restart ] ]'
         self.write(output + '\n')
 
     def call(self):
-        """
-        """
         try:
             opts, args = getopt.gnu_getopt(self.args, 'h', ['help', 'status-all', 'full-restart'])
         except getopt.GetoptError as err:

--- a/src/cowrie/commands/sleep.py
+++ b/src/cowrie/commands/sleep.py
@@ -20,13 +20,9 @@ class command_sleep(HoneyPotCommand):
     """
 
     def done(self):
-        """
-        """
         self.exit()
 
     def start(self):
-        """
-        """
         if len(self.args) == 1:
             _time = int(self.args[0])
             self.scheduled = reactor.callLater(_time, self.done)

--- a/src/cowrie/commands/ssh.py
+++ b/src/cowrie/commands/ssh.py
@@ -1,32 +1,26 @@
 # Copyright (c) 2009 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-"""
-"""
-
 from __future__ import division, absolute_import
 
-import time
-import re
-import hashlib
 import getopt
+import hashlib
+import re
 import socket
+import time
 
-from twisted.python import log
 from twisted.internet import reactor
+from twisted.python import log
 
 from cowrie.shell.command import HoneyPotCommand
+
 
 commands = {}
 
 
 class command_ssh(HoneyPotCommand):
-    """
-    """
 
     def valid_ip(self, address):
-        """
-        """
         try:
             socket.inet_aton(address)
             return True
@@ -34,8 +28,6 @@ class command_ssh(HoneyPotCommand):
             return False
 
     def start(self):
-        """
-        """
         try:
             optlist, args = getopt.getopt(self.args, '-1246AaCfgKkMNnqsTtVvXxYb:c:D:e:F:i:L:l:m:O:o:p:R:S:w:')
         except getopt.GetoptError as err:
@@ -84,8 +76,6 @@ class command_ssh(HoneyPotCommand):
         self.callbacks = [self.yesno, self.wait]
 
     def yesno(self, line):
-        """
-        """
         self.write(
             'Warning: Permanently added \'%s\' (RSA) to the list of known hosts.\n' % \
             self.host)
@@ -93,13 +83,9 @@ class command_ssh(HoneyPotCommand):
         self.protocol.password_input = True
 
     def wait(self, line):
-        """
-        """
         reactor.callLater(2, self.finish, line)
 
     def finish(self, line):
-        """
-        """
         self.pause = False
         rest, host = self.host, 'localhost'
         rest = self.host.strip().split('.')
@@ -117,8 +103,6 @@ class command_ssh(HoneyPotCommand):
         self.exit()
 
     def lineReceived(self, line):
-        """
-        """
         log.msg('INPUT (ssh):', line)
         if len(self.callbacks):
             self.callbacks.pop(0)(line)

--- a/src/cowrie/commands/sudo.py
+++ b/src/cowrie/commands/sudo.py
@@ -56,26 +56,18 @@ Options:
 
 
 class command_sudo(HoneyPotCommand):
-    """
-    """
 
     def short_help(self):
-        """
-        """
         for ln in sudo_shorthelp:
             self.errorWrite('{0}\n'.format(ln))
         self.exit()
 
     def long_help(self):
-        """
-        """
         for ln in sudo_longhelp:
             self.errorWrite('{0}\n'.format(ln))
         self.exit()
 
     def version(self):
-        """
-        """
         self.errorWrite(
             '''Sudo version 1.8.5p2
             Sudoers policy plugin version 1.8.5p2
@@ -85,8 +77,6 @@ class command_sudo(HoneyPotCommand):
         self.exit()
 
     def start(self):
-        """
-        """
         start_value = None
         parsed_arguments = []
         for count in range(0, len(self.args)):

--- a/src/cowrie/commands/tar.py
+++ b/src/cowrie/commands/tar.py
@@ -3,8 +3,8 @@
 
 from __future__ import division, absolute_import
 
-import tarfile
 import os
+import tarfile
 
 from twisted.python import log
 
@@ -15,12 +15,8 @@ commands = {}
 
 
 class command_tar(HoneyPotCommand):
-    """
-    """
 
     def mkfullpath(self, path, f):
-        """
-        """
         l, d = path.split('/'), []
         while len(l):
             d.append(l.pop(0))
@@ -28,8 +24,6 @@ class command_tar(HoneyPotCommand):
                 self.fs.mkdir('/'.join(d), 0, 0, 4096, f.mode, f.mtime)
 
     def call(self):
-        """
-        """
         if len(self.args) < 2:
             self.write('tar: You must specify one of the `-Acdtrux\' options\n')
             self.write('Try `tar --help\' or `tar --usage\' for more information.\n')

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -8,23 +8,19 @@ from twisted.python import log
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CONFIG
-from cowrie.shell.customparser import CustomParser, OptionNotFound
 from cowrie.shell.command import HoneyPotCommand
-
+from cowrie.shell.customparser import CustomParser, OptionNotFound
 
 commands = {}
 
 
 class Progress(object):
-    """
-    """
+
     def __init__(self, protocol):
         self.progress = 0
         self.out = protocol
 
     def progresshook(self, pkt):
-        """
-        """
         if isinstance(pkt, tftpy.TftpPacketDAT):
             self.progress += len(pkt.data)
             self.out.write("Transferred %d bytes" % self.progress + "\n")
@@ -33,16 +29,11 @@ class Progress(object):
 
 
 class command_tftp(HoneyPotCommand):
-    """
-    """
-
     port = 69
     hostname = None
     file_to_get = None
 
     def makeTftpRetrieval(self):
-        """
-        """
         progresshook = Progress(self).progresshook
 
         if CONFIG.has_option('honeypot', 'download_limit_size'):
@@ -93,8 +84,6 @@ class command_tftp(HoneyPotCommand):
             self.fs.chown(self.file_to_get, self.protocol.user.uid, self.protocol.user.gid)
 
     def start(self):
-        """
-        """
         parser = CustomParser(self)
         parser.prog = "tftp"
         parser.add_argument("hostname", nargs='?', default=None)

--- a/src/cowrie/commands/ulimit.py
+++ b/src/cowrie/commands/ulimit.py
@@ -21,8 +21,6 @@ class command_ulimit(HoneyPotCommand):
     ulimit: usage: ulimit [-SHacdfilmnpqstuvx] [limit]
     """
     def call(self):
-        """
-        """
         # Parse options or display no files
         try:
             opts, args = getopt.getopt(self.args, 'SHacdfilmnpqstuvx')
@@ -42,8 +40,6 @@ class command_ulimit(HoneyPotCommand):
         self.do_ulimit()
 
     def do_ulimit(self, key='core'):
-        """
-        """
         pass
 
 

--- a/src/cowrie/commands/uname.py
+++ b/src/cowrie/commands/uname.py
@@ -6,6 +6,7 @@ uname command
 """
 
 from __future__ import division, absolute_import
+
 from configparser import NoOptionError
 
 from cowrie.core.config import CONFIG
@@ -15,8 +16,6 @@ commands = {}
 
 
 def hardware_platform():
-    """
-    """
     try:
         return CONFIG.get('shell', 'hardware_platform')
     except NoOptionError:
@@ -24,8 +23,6 @@ def hardware_platform():
 
 
 def kernel_name():
-    """
-    """
     try:
         return CONFIG.get('shell', 'kernel_name')
     except NoOptionError:
@@ -33,8 +30,6 @@ def kernel_name():
 
 
 def kernel_version():
-    """
-    """
     try:
         return CONFIG.get('shell', 'kernel_version')
     except NoOptionError:
@@ -42,8 +37,6 @@ def kernel_version():
 
 
 def kernel_build_string():
-    """
-    """
     try:
         return CONFIG.get('shell', 'kernel_build_string')
     except NoOptionError:
@@ -51,8 +44,6 @@ def kernel_build_string():
 
 
 def operating_system():
-    """
-    """
     try:
         return CONFIG.get('shell', 'operating_system')
     except NoOptionError:
@@ -60,8 +51,6 @@ def operating_system():
 
 
 def uname_help():
-    """
-    """
     return """Usage: uname [OPTION]...
 Print certain system information.  With no OPTION, same as -s.
 
@@ -85,11 +74,8 @@ or available locally via: info '(coreutils) uname invocation'\n
 
 
 class command_uname(HoneyPotCommand):
-    """
-    """
+
     def full_uname(self):
-        """
-        """
         return '{} {} {} {} {} {}\n'.format(kernel_name(),
                                             self.protocol.hostname,
                                             kernel_version(),

--- a/src/cowrie/commands/uptime.py
+++ b/src/cowrie/commands/uptime.py
@@ -5,18 +5,15 @@ from __future__ import division, absolute_import
 
 import time
 
-from cowrie.shell.command import HoneyPotCommand
 from cowrie.core import utils
+from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
 
 
 class command_uptime(HoneyPotCommand):
-    """
-    """
+
     def call(self):
-        """
-        """
         self.write('%s  up %s,  1 user,  load average: 0.00, 0.00, 0.00\n' %
                    (time.strftime('%H:%M:%S'), utils.uptime(self.protocol.uptime())))
 

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -3,30 +3,23 @@
 
 from __future__ import division, absolute_import
 
-import time
-import os
 import getopt
+import os
+import time
 
 from OpenSSL import SSL
-
-from twisted.web import client
 from twisted.internet import reactor, ssl
 from twisted.python import log, compat
-
-from cowrie.shell.command import HoneyPotCommand
+from twisted.web import client
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CONFIG
-
-"""
-"""
+from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
 
 
 def tdiff(seconds):
-    """
-    """
     t = seconds
     days = int(t / (24 * 60 * 60))
     t -= (days * 24 * 60 * 60)
@@ -46,8 +39,6 @@ def tdiff(seconds):
 
 
 def sizeof_fmt(num):
-    """
-    """
     for x in ['bytes', 'K', 'M', 'G', 'T']:
         if num < 1024.0:
             return "%d%s" % (num, x)
@@ -56,19 +47,13 @@ def sizeof_fmt(num):
 
 # Luciano Ramalho @ http://code.activestate.com/recipes/498181/
 def splitthousands(s, sep=','):
-    """
-    """
     if len(s) <= 3: return s
     return splitthousands(s[:-3], sep) + sep + s[-3:]
 
 
 class command_wget(HoneyPotCommand):
-    """
-    """
 
     def start(self):
-        """
-        """
         try:
             optlist, args = getopt.getopt(self.args, 'cqO:P:', 'header=')
         except getopt.GetoptError as err:
@@ -182,14 +167,10 @@ class command_wget(HoneyPotCommand):
         return factory.deferred
 
     def handle_CTRL_C(self):
-        """
-        """
         self.errorWrite('^C\n')
         self.connection.transport.loseConnection()
 
     def success(self, data, outfile):
-        """
-        """
         if not os.path.isfile(self.artifactFile.shasumFilename):
             log.msg("there's no file " + self.artifactFile.shasumFilename)
             self.exit()
@@ -219,8 +200,6 @@ class command_wget(HoneyPotCommand):
         self.exit()
 
     def error(self, error, url):
-        """
-        """
         if hasattr(error, 'getErrorMessage'):  # exceptions
             errorMessage = error.getErrorMessage()
             self.errorWrite(errorMessage + '\n')
@@ -256,8 +235,6 @@ class HTTPProgressDownloader(client.HTTPDownloader):
         self.quiet = self.wget.quiet
 
     def noPage(self, reason):  # Called for non-200 responses
-        """
-        """
         if self.status == b'304':
             client.HTTPDownloader.page(self, '')
         else:
@@ -269,8 +246,6 @@ class HTTPProgressDownloader(client.HTTPDownloader):
             client.HTTPDownloader.noPage(self, reason)
 
     def gotHeaders(self, headers):
-        """
-        """
         if self.status == b'200':
             if not self.quiet:
                 self.wget.errorWrite('200 OK\n')
@@ -305,8 +280,6 @@ class HTTPProgressDownloader(client.HTTPDownloader):
         return client.HTTPDownloader.gotHeaders(self, headers)
 
     def pagePart(self, data):
-        """
-        """
         if self.status == b'200':
             self.currentlength += len(data)
 
@@ -337,8 +310,6 @@ class HTTPProgressDownloader(client.HTTPDownloader):
         return client.HTTPDownloader.pagePart(self, data)
 
     def pageEnd(self):
-        """
-        """
         if self.totallength != 0 and self.currentlength != self.totallength:
             return client.HTTPDownloader.pageEnd(self)
         if not self.quiet:

--- a/src/cowrie/commands/which.py
+++ b/src/cowrie/commands/which.py
@@ -12,7 +12,9 @@ class command_which(HoneyPotCommand):
     resolve_args = False
 
     def call(self):
-        """ Look up all the arguments on PATH and print each (first) result """
+        """
+        Look up all the arguments on PATH and print each (first) result
+        """
 
         # No arguments, just exit
         if not len(self.args) or 'PATH' not in self.environ:

--- a/src/cowrie/core/artifact.py
+++ b/src/cowrie/core/artifact.py
@@ -32,12 +32,8 @@ from cowrie.core.config import CONFIG
 
 
 class Artifact:
-    """
-    """
 
     def __init__(self, label):
-        """
-        """
         self.label = label
         self.artifactDir = CONFIG.get('honeypot', 'download_path')
 
@@ -49,28 +45,18 @@ class Artifact:
         self.shasumFilename = ''
 
     def __enter__(self):
-        """
-        """
         return self.fp
 
     def __exit__(self, exception_type, exception_value, trace):
-        """
-        """
         self.close()
 
     def write(self, bytes):
-        """
-        """
         self.fp.write(bytes)
 
     def fileno(self):
-        """
-        """
         return self.fp.fileno()
 
     def close(self, keepEmpty=False):
-        """
-        """
         size = self.fp.tell()
         self.fp.seek(0)
         data = self.fp.read()

--- a/src/cowrie/core/auth.py
+++ b/src/cowrie/core/auth.py
@@ -7,11 +7,11 @@ This module contains authentication code
 
 from __future__ import division, absolute_import
 
-import re
 import json
+import re
+from collections import OrderedDict
 from os import path
 from random import randint
-from collections import OrderedDict
 
 from twisted.python import log
 
@@ -24,8 +24,6 @@ class UserDB(object):
     """
 
     def __init__(self):
-        """
-        """
         self.userdb = OrderedDict()
         self.userdb_file = '{}/userdb.txt'.format(CONFIG.get('honeypot', 'data_path'))
         self.load()
@@ -34,7 +32,6 @@ class UserDB(object):
         """
         load the user db
         """
-
         with open(self.userdb_file, 'rb') as f:
             while True:
                 rawline = f.readline()
@@ -52,8 +49,6 @@ class UserDB(object):
                 self.adduser(login, passwd)
 
     def checklogin(self, thelogin, thepasswd, src_ip='0.0.0.0'):
-        """
-        """
         for credentials, policy in self.userdb.items():
             login, passwd = credentials
 
@@ -64,8 +59,6 @@ class UserDB(object):
         return False
 
     def match_rule(self, rule, input):
-        """
-        """
         if type(rule) is bytes:
             return rule in [b'*', input]
         else:

--- a/src/cowrie/core/cef.py
+++ b/src/cowrie/core/cef.py
@@ -26,9 +26,6 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-"""
-This module contains ...
-"""
 from __future__ import division, absolute_import
 
 #  cowrie.client.fingerprint

--- a/src/cowrie/core/checkers.py
+++ b/src/cowrie/core/checkers.py
@@ -9,19 +9,17 @@ from __future__ import division, absolute_import
 
 from sys import modules
 
-from zope.interface import implementer
-
+from twisted.conch import error
+from twisted.conch.ssh import keys
 from twisted.cred.checkers import ICredentialsChecker
 from twisted.cred.credentials import ISSHPrivateKey
 from twisted.cred.error import UnauthorizedLogin, UnhandledCredentials
 from twisted.internet import defer
 from twisted.python import log, failure
-from twisted.conch import error
-from twisted.conch.ssh import keys
+from zope.interface import implementer
 
-from cowrie.core import credentials
 from cowrie.core import auth
-
+from cowrie.core import credentials
 from cowrie.core.config import CONFIG
 
 
@@ -34,8 +32,6 @@ class HoneypotPublicKeyChecker(object):
     credentialInterfaces = (ISSHPrivateKey,)
 
     def requestAvatarId(self, credentials):
-        """
-        """
         _pubKey = keys.Key.fromString(credentials.blob)
         log.msg(eventid='cowrie.client.fingerprint',
                 format='public key attempt for user %(username)s of type %(type)s with fingerprint %(fingerprint)s',
@@ -56,8 +52,6 @@ class HoneypotNoneChecker(object):
     credentialInterfaces = (credentials.IUsername,)
 
     def requestAvatarId(self, credentials):
-        """
-        """
         return defer.succeed(credentials.username)
 
 
@@ -70,8 +64,6 @@ class HoneypotPasswordChecker(object):
     credentialInterfaces = (credentials.IUsernamePasswordIP, credentials.IPluggableAuthenticationModulesIP)
 
     def requestAvatarId(self, credentials):
-        """
-        """
         if hasattr(credentials, 'password'):
             if self.checkUserPass(credentials.username, credentials.password,
                                   credentials.ip):
@@ -84,22 +76,16 @@ class HoneypotPasswordChecker(object):
         return defer.fail(UnhandledCredentials())
 
     def checkPamUser(self, username, pamConversion, ip):
-        """
-        """
         r = pamConversion((('Password:', 1),))
         return r.addCallback(self.cbCheckPamUser, username, ip)
 
     def cbCheckPamUser(self, responses, username, ip):
-        """
-        """
         for (response, zero) in responses:
             if self.checkUserPass(username, response, ip):
                 return defer.succeed(username)
         return defer.fail(UnauthorizedLogin())
 
     def checkUserPass(self, theusername, thepassword, ip):
-        """
-        """
         # UserDB is the default auth_class
         authname = auth.UserDB
 

--- a/src/cowrie/core/config.py
+++ b/src/cowrie/core/config.py
@@ -7,8 +7,9 @@ This module contains ...
 
 from __future__ import division, absolute_import
 
-import configparser
 import os
+
+import configparser
 
 
 def to_environ_key(key):
@@ -16,8 +17,7 @@ def to_environ_key(key):
 
 
 class EnvironmentConfigParser(configparser.ConfigParser):
-    """
-    """
+
     def has_option(self, section, option):
         if to_environ_key('_'.join((section, option))) in os.environ:
             return True

--- a/src/cowrie/core/credentials.py
+++ b/src/cowrie/core/credentials.py
@@ -26,16 +26,10 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-"""
-This module contains ...
-"""
-
 from __future__ import division, absolute_import
 
+from twisted.cred.credentials import IUsernamePassword, ICredentials
 from zope.interface import implementer
-
-from twisted.cred.credentials import IUsernamePassword, \
-    ICredentials
 
 
 class IUsername(ICredentials):
@@ -82,8 +76,7 @@ class PluggableAuthenticationModulesIP(object):
 
 @implementer(IUsername)
 class Username(object):
-    """
-    """
+
     def __init__(self, username):
         self.username = username
 

--- a/src/cowrie/core/dblog.py
+++ b/src/cowrie/core/dblog.py
@@ -1,17 +1,14 @@
 # Copyright (c) 2009-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-"""
-This module contains ...
-"""
-
 from __future__ import division, absolute_import
 
+import abc
 import re
 import time
-import abc
 
 from cowrie.core.config import CONFIG
+
 
 # dblog now operates based on eventids, no longer on regex parsing of the entry.
 # add an eventid using keyword args and it will be picked up by the dblogger
@@ -62,7 +59,9 @@ class DBLogger(object):
         self.emit(ev)
 
     def start(self):
-        """Hook that can be used to set up connections in dbloggers"""
+        """
+        Hook that can be used to set up connections in dbloggers
+        """
         pass
 
     def getSensor(self):
@@ -71,7 +70,9 @@ class DBLogger(object):
         return None
 
     def nowUnix(self):
-        """return the current UTC time as an UNIX timestamp"""
+        """
+        return the current UTC time as an UNIX timestamp
+        """
         return int(time.time())
 
     def emit(self, ev):

--- a/src/cowrie/core/output.py
+++ b/src/cowrie/core/output.py
@@ -26,10 +26,6 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-"""
-This module contains ...
-"""
-
 from __future__ import division, absolute_import
 
 import abc
@@ -39,7 +35,6 @@ import socket
 import time
 
 from cowrie.core.config import CONFIG
-
 
 # Events:
 #  cowrie.client.fingerprint

--- a/src/cowrie/core/realm.py
+++ b/src/cowrie/core/realm.py
@@ -26,42 +26,29 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-"""
-This module contains ...
-"""
-
 from __future__ import division, absolute_import
-
-from zope.interface import implementer
-
-import sys
-import gc
 
 import twisted
 from twisted.conch import interfaces as conchinterfaces
 from twisted.conch.telnet import ITelnetProtocol
 from twisted.python import log
-
-from cowrie.shell import server as shellserver
-from cowrie.shell import avatar as shellavatar
-from cowrie.proxy import avatar as proxyavatar
-from cowrie.proxy import server as proxyserver
-from cowrie.telnet import session
+from zope.interface import implementer
 
 from cowrie.core.config import CONFIG
+from cowrie.proxy import avatar as proxyavatar
+from cowrie.proxy import server as proxyserver
+from cowrie.shell import avatar as shellavatar
+from cowrie.shell import server as shellserver
+from cowrie.telnet import session
 
 
 @implementer(twisted.cred.portal.IRealm)
 class HoneyPotRealm(object):
-    """
-    """
 
     def __init__(self):
         pass
 
     def requestAvatar(self, avatarId, mind, *interfaces):
-        """
-        """
         try:
             backend = CONFIG.get('honeypot', 'backend')
         except:

--- a/src/cowrie/core/ttylog.py
+++ b/src/cowrie/core/ttylog.py
@@ -9,8 +9,8 @@ Should be compatible with user mode linux
 
 from __future__ import division, absolute_import
 
-import struct
 import hashlib
+import struct
 
 OP_OPEN, OP_CLOSE, OP_WRITE, OP_EXEC = 1, 2, 3, 4
 TYPE_INPUT, TYPE_OUTPUT, TYPE_INTERACT = 1, 2, 3

--- a/src/cowrie/core/utils.py
+++ b/src/cowrie/core/utils.py
@@ -2,10 +2,6 @@
 # Copyright (c) 2010-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-"""
-This module contains ...
-"""
-
 from __future__ import division, absolute_import
 
 import sys
@@ -97,8 +93,6 @@ def uptime(total_seconds):
 
 
 def get_endpoints_from_section(cfg, section, default_port):
-    """
-    """
     if cfg.has_option(section, 'listen_endpoints'):
         return cfg.get(section, 'listen_endpoints').split()
 
@@ -120,8 +114,6 @@ def get_endpoints_from_section(cfg, section, default_port):
 
 
 def create_endpoint_services(reactor, parent, listen_endpoints, factory):
-    """
-    """
     for listen_endpoint in listen_endpoints:
 
         # work around http://twistedmatrix.com/trac/ticket/8422

--- a/src/cowrie/dblog/xmpp.py
+++ b/src/cowrie/dblog/xmpp.py
@@ -1,21 +1,19 @@
 
 from __future__ import division, absolute_import
 
-import uuid
 import json
+import uuid
 
-from twisted.words.xish import domish
-from twisted.python import log
-from twisted.words.protocols.jabber.jid import JID
 from twisted.application import service
+from twisted.python import log
 from twisted.words.protocols.jabber import jid
-
-from wokkel.xmppim import AvailablePresence
-from wokkel.client import XMPPClient
+from twisted.words.protocols.jabber.jid import JID
 from wokkel import muc
+from wokkel.client import XMPPClient
+from wokkel.xmppim import AvailablePresence
 
-from cowrie.core.config import CONFIG
 from cowrie.core import dblog
+from cowrie.core.config import CONFIG
 
 
 class XMPPLoggerProtocol(muc.MUCClient):
@@ -32,7 +30,8 @@ class XMPPLoggerProtocol(muc.MUCClient):
         self.activity = None
 
     def connectionInitialized(self):
-        """The bot has connected to the xmpp server, now try to join the room.
+        """
+        The bot has connected to the xmpp server, now try to join the room.
         """
         self.join(self.jrooms, self.nick)
 
@@ -81,7 +80,6 @@ class DBLogger(dblog.DBLogger):
         self.run(application, jid, password, JID(None, [muc, server, None]), channels)
 
     def run(self, application, jidstr, password, muc, channels, anon=True):
-
         self.xmppclient = XMPPClient(JID(jidstr), password)
         if CONFIG.has_option('database_xmpp', 'debug') and \
                 CONFIG.getboolean('database_xmpp', 'debug') == True:

--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -1,23 +1,18 @@
 # Copyright (c) 2009-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-"""
-This module contains ...
-"""
-
 from __future__ import division, absolute_import
 
+import hashlib
 import os
 import time
-import hashlib
 
-from twisted.python import log
 from twisted.conch.insults import insults
+from twisted.python import log
 
 from cowrie.core import ttylog
-from cowrie.shell import protocol
-
 from cowrie.core.config import CONFIG
+from cowrie.shell import protocol
 
 
 class LoggingServerProtocol(insults.ServerProtocol):
@@ -53,15 +48,11 @@ class LoggingServerProtocol(insults.ServerProtocol):
             self.type = 'i'  # Interactive
 
     def getSessionId(self):
-        """
-        """
         transportId = self.transport.session.conn.transport.transportId
         channelId = self.transport.session.id
         return (transportId, channelId)
 
     def connectionMade(self):
-        """
-        """
         transportId, channelId = self.getSessionId()
         self.startTime = time.time()
 
@@ -88,8 +79,6 @@ class LoggingServerProtocol(insults.ServerProtocol):
             ttylog.ttylog_write(self.ttylogFile, len(cmd), ttylog.TYPE_INTERACT, time.time(), cmd)
 
     def write(self, data):
-        """
-        """
         if self.ttylogEnabled and self.ttylogOpen:
             ttylog.ttylog_write(self.ttylogFile, len(data), ttylog.TYPE_OUTPUT, time.time(), data)
             self.ttylogSize += len(data)

--- a/src/cowrie/output/csirtg.py
+++ b/src/cowrie/output/csirtg.py
@@ -1,13 +1,13 @@
 from __future__ import division, absolute_import
 
-import cowrie.core.output
-
-from csirtgsdk.indicator import Indicator
-from csirtgsdk.client import Client
-from datetime import datetime
 import os
+from datetime import datetime
+
+from csirtgsdk.client import Client
+from csirtgsdk.indicator import Indicator
 from twisted.python import log
 
+import cowrie.core.output
 from cowrie.core.config import CONFIG
 
 USERNAME = os.environ.get('CSIRTG_USER')

--- a/src/cowrie/output/cuckoo.py
+++ b/src/cowrie/output/cuckoo.py
@@ -47,8 +47,6 @@ from cowrie.core.config import CONFIG
 
 
 class Output(cowrie.core.output.Output):
-    """
-    """
 
     def __init__(self):
         self.url_base = CONFIG.get('output_cuckoo', 'url_base').encode('utf-8')
@@ -70,8 +68,6 @@ class Output(cowrie.core.output.Output):
         pass
 
     def write(self, entry):
-        """
-        """
         if entry["eventid"] == "cowrie.session.file_download":
             print("Sending file to Cuckoo")
             p = urlparse(entry["url"]).path

--- a/src/cowrie/output/dshield.py
+++ b/src/cowrie/output/dshield.py
@@ -5,24 +5,23 @@ See https://isc.sans.edu/ssh.html
 
 from __future__ import division, absolute_import
 
-import dateutil.parser
-import time
 import base64
-import hmac
+import dateutil.parser
 import hashlib
-import requests
+import hmac
 import re
+import time
 
-from twisted.python import log
+import requests
 from twisted.internet import threads, reactor
+from twisted.python import log
 
 import cowrie.core.output
 from cowrie.core.config import CONFIG
 
 
 class Output(cowrie.core.output.Output):
-    """
-    """
+
     def __init__(self):
         self.auth_key = CONFIG.get('output_dshield', 'auth_key')
         self.userid = CONFIG.get('output_dshield', 'userid')

--- a/src/cowrie/output/elasticsearch.py
+++ b/src/cowrie/output/elasticsearch.py
@@ -5,17 +5,13 @@ from __future__ import division, absolute_import
 from elasticsearch import Elasticsearch
 
 import cowrie.core.output
-
 from cowrie.core.config import CONFIG
 
 
 class Output(cowrie.core.output.Output):
-    """
-    """
 
     def __init__(self):
-        """
-        """
+
         self.host = CONFIG.get('output_elasticsearch', 'host')
         self.port = CONFIG.get('output_elasticsearch', 'port')
         self.index = CONFIG.get('output_elasticsearch', 'index')
@@ -24,18 +20,12 @@ class Output(cowrie.core.output.Output):
         cowrie.core.output.Output.__init__(self)
 
     def start(self):
-        """
-        """
         self.es = Elasticsearch('{0}:{1}'.format(self.host, self.port))
 
     def stop(self):
-        """
-        """
         pass
 
     def write(self, logentry):
-        """
-        """
         for i in list(logentry.keys()):
             # remove twisted 15 legacy keys
             if i.startswith('log_'):

--- a/src/cowrie/output/hpfeeds.py
+++ b/src/cowrie/output/hpfeeds.py
@@ -5,16 +5,15 @@ Output plugin for HPFeeds
 
 from __future__ import division, absolute_import
 
-import os
-import struct
 import hashlib
 import json
+import os
 import socket
+import struct
 
 from twisted.python import log
 
 import cowrie.core.output
-
 from cowrie.core.config import CONFIG
 
 try:
@@ -58,7 +57,7 @@ def set2json(value):
 
 def strpack8(x):
     """
-    # packs a string with 1 byte length field
+    packs a string with 1 byte length field
     """
     if isinstance(x, str): x = x.encode('latin1')
     return struct.pack('!B', len(x)) + x
@@ -250,8 +249,7 @@ class Output(cowrie.core.output.Output):
         cowrie.core.output.Output.__init__(self)
 
     def start(self):
-        """
-        """
+
         server = CONFIG.get('output_hpfeeds', 'server')
         port = CONFIG.getint('output_hpfeeds', 'port')
         ident = CONFIG.get('output_hpfeeds', 'identifier')
@@ -261,13 +259,9 @@ class Output(cowrie.core.output.Output):
         self.meta = {}
 
     def stop(self):
-        """
-        """
         pass
 
     def write(self, entry):
-        """
-        """
         session = entry["session"]
         if entry["eventid"] == 'cowrie.session.connect':
             self.meta[session] = {

--- a/src/cowrie/output/hpfeeds3.py
+++ b/src/cowrie/output/hpfeeds3.py
@@ -1,10 +1,10 @@
 
 """
 Output plugin for HPFeeds
-
 """
 
 from __future__ import division, absolute_import
+
 import json
 import logging
 
@@ -24,8 +24,6 @@ class Output(cowrie.core.output.Output):
     channel = 'cowrie.sessions'
 
     def start(self):
-        """
-        """
         log.msg("WARNING: Beta version of new hpfeeds enabled. This will become hpfeeds in a future release.")
 
         if CONFIG.has_option('output_hpfeeds', 'channel'):
@@ -54,13 +52,9 @@ class Output(cowrie.core.output.Output):
         self.client.startService()
 
     def stop(self):
-        """
-        """
         self.client.stopService()
 
     def write(self, entry):
-        """
-        """
         session = entry["session"]
         if entry["eventid"] == 'cowrie.session.connect':
             self.meta[session] = {

--- a/src/cowrie/output/influx.py
+++ b/src/cowrie/output/influx.py
@@ -1,9 +1,8 @@
 import re
 
-from twisted.python import log
-
 from influxdb import InfluxDBClient
 from influxdb.exceptions import InfluxDBClientError
+from twisted.python import log
 
 import cowrie.core.output
 from cowrie.core.config import CONFIG
@@ -15,8 +14,6 @@ class Output(cowrie.core.output.Output):
         cowrie.core.output.Output.__init__(self)
 
     def start(self):
-        """
-        """
         try:
             host = CONFIG.get('output_influx', 'host')
         except:

--- a/src/cowrie/output/jsonlog.py
+++ b/src/cowrie/output/jsonlog.py
@@ -26,10 +26,6 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-"""
-Docstring
-"""
-
 from __future__ import division, absolute_import
 
 import json
@@ -37,14 +33,10 @@ import os
 
 import cowrie.core.output
 import cowrie.python.logfile
-
 from cowrie.core.config import CONFIG
 
 
 class Output(cowrie.core.output.Output):
-    """
-    Docstring class
-    """
 
     def __init__(self):
         cowrie.core.output.Output.__init__(self)
@@ -54,18 +46,12 @@ class Output(cowrie.core.output.Output):
         self.outfile = cowrie.python.logfile.CowrieDailyLogFile(base, dirs, defaultMode=0o664)
 
     def start(self):
-        """
-        """
         pass
 
     def stop(self):
-        """
-        """
         self.outfile.flush()
 
     def write(self, logentry):
-        """
-        """
         for i in list(logentry.keys()):
             # Remove twisted 15 legacy keys
             if i.startswith('log_') or i == 'time' or i == 'system':

--- a/src/cowrie/output/kafka.py
+++ b/src/cowrie/output/kafka.py
@@ -37,16 +37,14 @@ import logging
 import random
 import string
 
+from afkak.client import KafkaClient
+from afkak.partitioner import RoundRobinPartitioner, HashedPartitioner
+from afkak.producer import Producer
 from twisted.internet import defer, task
 from twisted.python import log
 
-from afkak.client import KafkaClient
-from afkak.producer import Producer
-from afkak.partitioner import RoundRobinPartitioner, HashedPartitioner
-
 import cowrie.core.output
 import cowrie.python.logfile
-
 from cowrie.core.config import CONFIG
 
 
@@ -129,9 +127,6 @@ def main():
 
 
 class Output(cowrie.core.output.Output):
-    """
-    Docstring class
-    """
 
     def __init__(self):
         cowrie.core.output.Output.__init__(self)
@@ -140,18 +135,12 @@ class Output(cowrie.core.output.Output):
         topic = CONFIG.get('output_kafka', 'topic')
 
     def start(self):
-        """
-        """
         pass
 
     def stop(self):
-        """
-        """
         self.outfile.flush()
 
     def write(self, logentry):
-        """
-        """
         for i in list(logentry.keys()):
             # Remove twisted 15 legacy keys
             if i.startswith('log_'):

--- a/src/cowrie/output/localsyslog.py
+++ b/src/cowrie/output/localsyslog.py
@@ -31,17 +31,14 @@ from __future__ import division, absolute_import
 import syslog
 import twisted.python.syslog
 
-import cowrie.core.output
 import cowrie.core.cef
-
+import cowrie.core.output
 from cowrie.core.config import CONFIG
 
 
 class Output(cowrie.core.output.Output):
 
     def __init__(self):
-        """
-        """
         facilityString = CONFIG.get('output_localsyslog', 'facility')
         self.format = CONFIG.get('output_localsyslog', 'format')
         self.facility = vars(syslog)['LOG_' + facilityString]
@@ -49,18 +46,12 @@ class Output(cowrie.core.output.Output):
         cowrie.core.output.Output.__init__(self)
 
     def start(self):
-        """
-        """
         pass
 
     def stop(self):
-        """
-        """
         pass
 
     def write(self, logentry):
-        """
-        """
         if self.format == 'cef':
             self.syslog.emit({
                 'message': cowrie.core.cef.formatCef(logentry),

--- a/src/cowrie/output/malshare.py
+++ b/src/cowrie/output/malshare.py
@@ -34,10 +34,11 @@ More info https://malshare.com/doc.php
 from __future__ import division, absolute_import
 
 import os
+
 try:
     from urllib.parse import urlparse
 except ImportError:
-    from urlparse import urlparse, urljoin
+    from urlparse import urlparse
 import requests
 
 import cowrie.core.output
@@ -45,8 +46,6 @@ from cowrie.core.config import CONFIG
 
 
 class Output(cowrie.core.output.Output):
-    """
-    """
 
     def __init__(self):
         self.enabled = CONFIG.getboolean('output_malshare', 'enabled')
@@ -65,8 +64,6 @@ class Output(cowrie.core.output.Output):
         pass
 
     def write(self, entry):
-        """
-        """
         if entry["eventid"] == "cowrie.session.file_download":
             print("Sending file to MalShare")
             p = urlparse(entry["url"]).path

--- a/src/cowrie/output/mongodb.py
+++ b/src/cowrie/output/mongodb.py
@@ -3,7 +3,6 @@
 from __future__ import division, absolute_import
 
 import pymongo
-
 from twisted.python import log
 
 import cowrie.core.output
@@ -11,8 +10,6 @@ from cowrie.core.config import CONFIG
 
 
 class Output(cowrie.core.output.Output):
-    """
-    """
 
     def __init__(self):
         cowrie.core.output.Output.__init__(self)
@@ -32,8 +29,6 @@ class Output(cowrie.core.output.Output):
             log.msg('mongo error - {0}'.format(e))
 
     def start(self):
-        """
-        """
         db_addr = CONFIG.get('output_mongodb', 'connection_string')
         db_name = CONFIG.get('output_mongodb', 'database')
 
@@ -55,13 +50,9 @@ class Output(cowrie.core.output.Output):
             log.msg('output_mongodb: Error: %s' % str(e))
 
     def stop(self):
-        """
-        """
         self.mongo_client.close()
 
     def write(self, entry):
-        """
-        """
         for i in list(entry.keys()):
             # Remove twisted 15 legacy keys
             if i.startswith('log_'):

--- a/src/cowrie/output/mysql.py
+++ b/src/cowrie/output/mysql.py
@@ -6,13 +6,11 @@ MySQL output connector. Writes audit logs to MySQL database
 from __future__ import division, absolute_import
 
 import MySQLdb
-
-from twisted.internet import defer
 from twisted.enterprise import adbapi
+from twisted.internet import defer
 from twisted.python import log
 
 import cowrie.core.output
-
 from cowrie.core.config import CONFIG
 
 
@@ -44,9 +42,6 @@ class ReconnectingConnectionPool(adbapi.ConnectionPool):
 
 
 class Output(cowrie.core.output.Output):
-    """
-    docstring here
-    """
     db = None
 
     def __init__(self):
@@ -58,10 +53,6 @@ class Output(cowrie.core.output.Output):
         cowrie.core.output.Output.__init__(self)
 
     def start(self):
-        """
-        docstring here
-        """
-
         try:
             port = CONFIG.getint('output_mysql', 'port')
         except:
@@ -82,15 +73,9 @@ class Output(cowrie.core.output.Output):
             log.msg("output_mysql: Error %d: %s" % (e.args[0], e.args[1]))
 
     def stop(self):
-        """
-        docstring here
-        """
         self.db.close()
 
     def sqlerror(self, error):
-        """
-        docstring here
-        """
         log.err('output_mysql: MySQL Error: {}'.format(error.value))
 
     def simpleQuery(self, sql, args):
@@ -104,10 +89,6 @@ class Output(cowrie.core.output.Output):
 
     @defer.inlineCallbacks
     def write(self, entry):
-        """
-        docstring here
-        """
-
         if entry["eventid"] == 'cowrie.session.connect':
             r = yield self.db.runQuery(
                 "SELECT `id` FROM `sensors` WHERE `ip` = %s", (self.sensor,))

--- a/src/cowrie/output/redis.py
+++ b/src/cowrie/output/redis.py
@@ -1,11 +1,12 @@
 from __future__ import division, absolute_import
 
-import cowrie.core.output
-from cowrie.core.config import CONFIG
+import json
 
 import redis
-import json
 from ConfigParser import NoOptionError
+
+import cowrie.core.output
+from cowrie.core.config import CONFIG
 
 SEND_METHODS = {
     'lpush': lambda redis_client, key, message: redis_client.lpush(key, message),

--- a/src/cowrie/output/rethinkdblog.py
+++ b/src/cowrie/output/rethinkdblog.py
@@ -2,10 +2,10 @@ from __future__ import division, absolute_import
 
 import time
 from datetime import datetime
+
 import rethinkdb as r
 
 import cowrie.core.output
-
 from cowrie.core.config import CONFIG
 
 
@@ -14,14 +14,10 @@ def iso8601_to_timestamp(value):
 
 
 class Output(cowrie.core.output.Output):
-    """
-    """
 
     RETHINK_DB_SEGMENT = 'output_rethinkdblog'
 
     def __init__(self):
-        """
-        """
         self.host = CONFIG.get(self.RETHINK_DB_SEGMENT, 'host')
         self.port = CONFIG.getint(self.RETHINK_DB_SEGMENT, 'port')
         self.db = CONFIG.get(self.RETHINK_DB_SEGMENT, 'db')
@@ -31,8 +27,6 @@ class Output(cowrie.core.output.Output):
 
     # noinspection PyAttributeOutsideInit
     def start(self):
-        """
-        """
         self.connection = r.connect(
             host=self.host,
             port=self.port,
@@ -46,13 +40,9 @@ class Output(cowrie.core.output.Output):
             pass
 
     def stop(self):
-        """
-        """
         self.connection.close()
 
     def write(self, logentry):
-        """
-        """
         for i in list(logentry.keys()):
             # remove twisted 15 legacy keys
             if i.startswith('log_'):

--- a/src/cowrie/output/s3.py
+++ b/src/cowrie/output/s3.py
@@ -3,13 +3,12 @@ Send downloaded/uplaoded files to S3 (or compatible)
 """
 
 from __future__ import division, absolute_import
-from configparser import NoOptionError
 
+from botocore.exceptions import ClientError
+from botocore.session import get_session
+from configparser import NoOptionError
 from twisted.internet import defer, threads
 from twisted.python import log
-
-from botocore.session import get_session
-from botocore.exceptions import ClientError
 
 import cowrie.core.output
 from cowrie.core.config import CONFIG

--- a/src/cowrie/output/slack.py
+++ b/src/cowrie/output/slack.py
@@ -26,10 +26,6 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-"""
-Docstring
-"""
-
 from __future__ import division, absolute_import
 
 import json
@@ -42,9 +38,6 @@ from cowrie.core.config import CONFIG
 
 
 class Output(cowrie.core.output.Output):
-    """
-    Docstring class
-    """
 
     def __init__(self):
         self.slack_channel = CONFIG.get('output_slack', 'channel')
@@ -52,18 +45,12 @@ class Output(cowrie.core.output.Output):
         cowrie.core.output.Output.__init__(self)
 
     def start(self):
-        """
-        """
         pass
 
     def stop(self):
-        """
-        """
         pass
 
     def write(self, logentry):
-        """
-        """
         for i in list(logentry.keys()):
             # Remove twisted 15 legacy keys
             if i.startswith('log_'):

--- a/src/cowrie/output/splunk.py
+++ b/src/cowrie/output/splunk.py
@@ -8,24 +8,20 @@ JSON log file is still recommended way to go
 
 from __future__ import division, absolute_import
 
+import json
 from StringIO import StringIO
 
-import json
-
-from twisted.python import log
 from twisted.internet import reactor
+from twisted.internet.ssl import ClientContextFactory
+from twisted.python import log
 from twisted.web import client, http_headers
 from twisted.web.client import FileBodyProducer
-from twisted.internet.ssl import ClientContextFactory
 
 import cowrie.core.output
-
 from cowrie.core.config import CONFIG
 
 
 class Output(cowrie.core.output.Output):
-    """
-    """
 
     def __init__(self):
         """
@@ -54,19 +50,13 @@ class Output(cowrie.core.output.Output):
         cowrie.core.output.Output.__init__(self)
 
     def start(self):
-        """
-        """
         contextFactory = WebClientContextFactory()
         self.agent = client.Agent(reactor, contextFactory)
 
     def stop(self):
-        """
-        """
         pass
 
     def write(self, logentry):
-        """
-        """
         for i in list(logentry.keys()):
             # Remove twisted 15 legacy keys
             if i.startswith('log_'):
@@ -131,9 +121,6 @@ class Output(cowrie.core.output.Output):
 
 
 class WebClientContextFactory(ClientContextFactory):
-    """
-    """
+
     def getContext(self, hostname, port):
-        """
-        """
         return ClientContextFactory.getContext(self)

--- a/src/cowrie/output/splunklegacy.py
+++ b/src/cowrie/output/splunklegacy.py
@@ -21,8 +21,6 @@ from cowrie.core.config import CONFIG
 
 
 class Output(cowrie.core.output.Output):
-    """
-    """
 
     def __init__(self):
         """
@@ -36,8 +34,6 @@ class Output(cowrie.core.output.Output):
         cowrie.core.output.Output.__init__(self)
 
     def start(self):
-        """
-        """
         self.service = client.connect(
             host=self.host,
             port=self.port,
@@ -46,13 +42,9 @@ class Output(cowrie.core.output.Output):
         self.index = self.service.indexes['cowrie']
 
     def stop(self):
-        """
-        """
         pass
 
     def write(self, logentry):
-        """
-        """
         for i in list(logentry.keys()):
             # Remove twisted 15 legacy keys
             if i.startswith('log_'):

--- a/src/cowrie/output/sqlite.py
+++ b/src/cowrie/output/sqlite.py
@@ -1,23 +1,16 @@
-
-"""
-"""
-
 from __future__ import division, absolute_import
 
 import sqlite3
 
-from twisted.internet import defer
 from twisted.enterprise import adbapi
+from twisted.internet import defer
 from twisted.python import log
 
 import cowrie.core.output
-
 from cowrie.core.config import CONFIG
 
 
 class Output(cowrie.core.output.Output):
-    """
-    """
 
     def __init__(self):
         cowrie.core.output.Output.__init__(self)
@@ -47,9 +40,6 @@ class Output(cowrie.core.output.Output):
         self.db.close()
 
     def sqlerror(self, error):
-        """
-        docstring here
-        """
         log.err('sqlite error')
         error.printTraceback()
 
@@ -62,10 +52,6 @@ class Output(cowrie.core.output.Output):
 
     @defer.inlineCallbacks
     def write(self, entry):
-        """
-        docstring here
-        """
-
         if entry["eventid"] == 'cowrie.session.connect':
             r = yield self.db.runQuery(
                 "SELECT `id` FROM `sensors` WHERE `ip` = ?", (self.sensor,))

--- a/src/cowrie/output/textlog.py
+++ b/src/cowrie/output/textlog.py
@@ -28,33 +28,26 @@
 
 from __future__ import division, absolute_import
 
-import cowrie.core.output
 import cowrie.core.cef
+import cowrie.core.output
 from cowrie.core.config import CONFIG
 
 
 class Output(cowrie.core.output.Output):
 
     def __init__(self):
-        """
-        """
+
         self.format = CONFIG.get('output_textlog', 'format')
         self.outfile = open(CONFIG.get('output_textlog', 'logfile'), 'a')
         cowrie.core.output.Output.__init__(self)
 
     def start(self):
-        """
-        """
         pass
 
     def stop(self):
-        """
-        """
         pass
 
     def write(self, logentry):
-        """
-        """
         if self.format == 'cef':
             self.outfile.write('{0} '.format(logentry['timestamp']))
             self.outfile.write('{0}\n'.format(cowrie.core.cef.formatCef(logentry)))

--- a/src/cowrie/output/virustotal.py
+++ b/src/cowrie/output/virustotal.py
@@ -33,8 +33,6 @@ Work in Progress - not functional yet
 
 from __future__ import division, absolute_import
 
-from zope.interface import implementer
-
 import json
 import os
 
@@ -49,9 +47,9 @@ from twisted.web.iweb import IBodyProducer
 from twisted.internet import defer, reactor
 from twisted.web import client, http_headers
 from twisted.internet.ssl import ClientContextFactory
+from zope.interface import implementer
 
 import cowrie.core.output
-
 from cowrie.core.config import CONFIG
 
 
@@ -61,8 +59,6 @@ COMMENT = "First seen by #Cowrie SSH/telnet Honeypot http://github.com/micheloos
 
 
 class Output(cowrie.core.output.Output):
-    """
-    """
 
     def __init__(self):
         self.apiKey = CONFIG.get('output_virustotal', 'api_key')
@@ -85,8 +81,6 @@ class Output(cowrie.core.output.Output):
         pass
 
     def write(self, entry):
-        """
-        """
         if entry["eventid"] == 'cowrie.session.file_download':
             # TODO: RENABLE file upload to virustotal (git commit 6546f1ee)
             log.msg("Checking scan report at VT")
@@ -199,8 +193,6 @@ class Output(cowrie.core.output.Output):
             return processResult(failure.value.response)
 
         def cbResponse(response):
-            """
-            """
             if response.code == 200:
                 d = client.readBody(response)
                 d.addCallback(cbBody)
@@ -211,13 +203,9 @@ class Output(cowrie.core.output.Output):
                 return
 
         def cbError(failure):
-            """
-            """
             failure.printTraceback()
 
         def processResult(result):
-            """
-            """
             if self.debug:
                 log.msg("VT postfile result: {}".format(result))
             j = json.loads(result)
@@ -310,8 +298,6 @@ class Output(cowrie.core.output.Output):
         d = self.agent.request(b'POST', vtUrl, headers, body)
 
         def cbBody(body):
-            """
-            """
             return processResult(body)
 
         def cbPartial(failure):
@@ -321,8 +307,6 @@ class Output(cowrie.core.output.Output):
             return processResult(failure.value.response)
 
         def cbResponse(response):
-            """
-            """
             if response.code == 200:
                 d = client.readBody(response)
                 d.addCallback(cbBody)
@@ -333,13 +317,9 @@ class Output(cowrie.core.output.Output):
                 return
 
         def cbError(failure):
-            """
-            """
             failure.printTraceback()
 
         def processResult(result):
-            """
-            """
             if self.debug:
                 log.msg("VT postcomment result: {}".format(result))
             j = json.loads(result)
@@ -351,35 +331,27 @@ class Output(cowrie.core.output.Output):
 
 
 class WebClientContextFactory(ClientContextFactory):
-    """
-    """
+
     def getContext(self, hostname, port):
         return ClientContextFactory.getContext(self)
 
 
 @implementer(IBodyProducer)
 class StringProducer(object):
-    """
-    """
 
     def __init__(self, body):
         self.body = body
         self.length = len(body)
 
     def startProducing(self, consumer):
-        """
-        """
+
         consumer.write(self.body)
         return defer.succeed(None)
 
     def pauseProducing(self):
-        """
-        """
         pass
 
     def stopProducing(self):
-        """
-        """
         pass
 
 

--- a/src/cowrie/output/xmpp.py
+++ b/src/cowrie/output/xmpp.py
@@ -2,17 +2,16 @@
 from __future__ import division, absolute_import
 
 import json
+import string
+from random import choice
 
-from twisted.words.xish import domish
-from twisted.python import log
-from twisted.words.protocols.jabber.jid import JID
-from twisted.internet import defer
 from twisted.application import service
+from twisted.python import log
 from twisted.words.protocols.jabber import jid
-
-from wokkel.xmppim import AvailablePresence
-from wokkel.client import XMPPClient
+from twisted.words.protocols.jabber.jid import JID
 from wokkel import muc
+from wokkel.client import XMPPClient
+from wokkel.xmppim import AvailablePresence
 
 import cowrie.core.output
 from cowrie.core.config import CONFIG
@@ -32,7 +31,8 @@ class XMPPLoggerProtocol(muc.MUCClient):
         self.activity = None
 
     def connectionInitialized(self):
-        """The bot has connected to the xmpp server, now try to join the room.
+        """
+        The bot has connected to the xmpp server, now try to join the room.
         """
         self.join(self.jrooms, self.nick)
 
@@ -64,9 +64,6 @@ class Output(cowrie.core.output.Output):
         cowrie.core.output.Output.__init__(self)
 
     def start(self):
-        from random import choice
-        import string
-
         server = CONFIG.get('output_xmpp', 'server')
         user = CONFIG.get('output_xmpp', 'user')
         password = CONFIG.get('output_xmpp', 'password')
@@ -78,7 +75,6 @@ class Output(cowrie.core.output.Output):
         self.run(application, jid, password, JID(None, [muc, server, None]), server)
 
     def run(self, application, jidstr, password, muc, server):
-
         self.xmppclient = XMPPClient(JID(jidstr), password)
         if CONFIG.has_option('output_xmpp', 'debug') and \
                 CONFIG.getboolean('output_xmpp', 'debug') is True:

--- a/src/cowrie/proxy/avatar.py
+++ b/src/cowrie/proxy/avatar.py
@@ -7,24 +7,20 @@ This module contains ...
 
 from __future__ import division, absolute_import
 
-from zope.interface import implementer
 from configparser import NoOptionError
-
 from twisted.conch import avatar
 from twisted.conch.interfaces import IConchUser, ISession
 from twisted.python import log, components
-
-from cowrie.ssh import forwarding
-from cowrie.proxy import session as proxysession
-from cowrie.shell import session as shellsession
+from zope.interface import implementer
 
 from cowrie.core.config import CONFIG
+from cowrie.proxy import session as proxysession
+from cowrie.shell import session as shellsession
+from cowrie.ssh import forwarding
 
 
 @implementer(IConchUser)
 class CowrieUser(avatar.ConchUser):
-    """
-    """
 
     def __init__(self, username, server):
         avatar.ConchUser.__init__(self)
@@ -44,8 +40,6 @@ class CowrieUser(avatar.ConchUser):
             pass
 
     def logout(self):
-        """
-        """
         log.msg('avatar {} logging out'.format(self.username))
 
 

--- a/src/cowrie/proxy/endpoints.py
+++ b/src/cowrie/proxy/endpoints.py
@@ -9,31 +9,29 @@ Endpoint implementations of various SSH interactions.
 __all__ = [
     'AuthenticationFailed', 'SSHCommandAddress', 'SSHCommandClientEndpoint']
 
-from struct import unpack
 from os.path import expanduser
+from struct import unpack
 
-from zope.interface import Interface, implementer
-
-from twisted.python import log
-from twisted.python.compat import nativeString, networkString
-from twisted.python.filepath import FilePath
-from twisted.python.failure import Failure
+from twisted.conch.client.agent import SSHAgentClient
+from twisted.conch.client.default import _KNOWN_HOSTS
+from twisted.conch.client.knownhosts import ConsoleUI, KnownHostsFile
+from twisted.conch.ssh.channel import SSHChannel
+from twisted.conch.ssh.common import NS
+from twisted.conch.ssh.connection import SSHConnection
+from twisted.conch.ssh.keys import Key
+from twisted.conch.ssh.session import SSHSession, packRequest_pty_req
+from twisted.conch.ssh.transport import SSHClientTransport
+from twisted.conch.ssh.userauth import SSHUserAuthClient
+from twisted.internet.defer import Deferred, succeed, CancelledError
+from twisted.internet.endpoints import TCP4ClientEndpoint, connectProtocol
 from twisted.internet.error import ConnectionDone, ProcessTerminated
 from twisted.internet.interfaces import IStreamClientEndpoint
 from twisted.internet.protocol import Factory
-from twisted.internet.defer import Deferred, succeed, CancelledError
-from twisted.internet.endpoints import TCP4ClientEndpoint, connectProtocol
-
-from twisted.conch.ssh.keys import Key
-from twisted.conch.ssh.common import NS
-from twisted.conch.ssh.transport import SSHClientTransport
-from twisted.conch.ssh.connection import SSHConnection
-from twisted.conch.ssh.userauth import SSHUserAuthClient
-from twisted.conch.ssh.channel import SSHChannel
-from twisted.conch.ssh.session import SSHSession, packRequest_pty_req
-from twisted.conch.client.knownhosts import ConsoleUI, KnownHostsFile
-from twisted.conch.client.agent import SSHAgentClient
-from twisted.conch.client.default import _KNOWN_HOSTS
+from twisted.python import log
+from twisted.python.compat import nativeString, networkString
+from twisted.python.failure import Failure
+from twisted.python.filepath import FilePath
+from zope.interface import Interface, implementer
 
 
 class AuthenticationFailed(Exception):

--- a/src/cowrie/proxy/server.py
+++ b/src/cowrie/proxy/server.py
@@ -26,10 +26,6 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-"""
-This module contains ...
-"""
-
 from __future__ import division, absolute_import
 
 from cowrie.core.config import CONFIG

--- a/src/cowrie/proxy/session.py
+++ b/src/cowrie/proxy/session.py
@@ -1,19 +1,14 @@
 # Copyright (c) 2017 Michel Oosterhof <michel@oosterhof.net>
 # See the COPYRIGHT file for more information
 
-"""
-This module contains ...
-"""
-
 from __future__ import division, absolute_import
 
 from configparser import NoOptionError
-
+from twisted.conch.client.knownhosts import KnownHostsFile
+from twisted.conch.ssh import common, keys, session
+from twisted.conch.ssh.common import getNS
 from twisted.internet import reactor, protocol
 from twisted.python import log
-from twisted.conch.ssh import common, keys, session
-from twisted.conch.client.knownhosts import KnownHostsFile
-from twisted.conch.ssh.common import getNS
 
 from cowrie.core.config import CONFIG
 from cowrie.proxy import endpoints
@@ -30,8 +25,7 @@ class _ProtocolFactory():
         self.protocol = protocol
 
     def buildProtocol(self, addr):
-        """
-        """
+
         return self.protocol
 
 
@@ -87,13 +81,9 @@ class InBetween(protocol.Protocol):
         self.client.write(data)
 
     def closed(self):
-        """
-        """
         log.msg("IB: closed")
 
     def closeReceived(self):
-        """
-        """
         log.msg("IB: closeRecieved")
 
     def loseConnection(self):
@@ -110,8 +100,6 @@ class InBetween(protocol.Protocol):
         self.client.loseConnection()
 
     def eofReceived(self):
-        """
-        """
         log.msg("IB: eofReceived")
 
 
@@ -177,20 +165,14 @@ class ProxySSHSession(channel.CowrieSSHChannel):
         return d
 
     def _ebConnect(self):
-        """
-        """
         log.msg("ERROR CONNECTED TO BACKEND")
         self._state = b'ERROR'
 
     def _cbConnect(self):
-        """
-        """
         log.msg("CONNECTED TO BACKEND")
         self._state = b'CONNECTED'
 
     def request_env(self, data):
-        """
-        """
         name, rest = getNS(data)
         value, rest = getNS(rest)
         if rest:
@@ -202,28 +184,20 @@ class ProxySSHSession(channel.CowrieSSHChannel):
         return 0
 
     def request_pty_req(self, data):
-        """
-        """
         term, windowSize, modes = session.parseRequest_pty_req(data)
         log.msg('pty request: %r %r' % (term, windowSize))
         return 1
 
     def request_window_change(self, data):
-        """
-        """
         winSize = session.parseRequest_window_change(data)
         return 1
 
     def request_subsystem(self, data):
-        """
-        """
         subsystem, _ = common.getNS(data)
         log.msg('asking for subsystem "{}"'.format(subsystem))
         return 0
 
     def request_exec(self, data):
-        """
-        """
         cmd, data = common.getNS(data)
         log.msg('request_exec "{}"'.format(cmd))
         pf = _ProtocolFactory(self.client.transport)
@@ -232,8 +206,6 @@ class ProxySSHSession(channel.CowrieSSHChannel):
         return 1
 
     def request_shell(self, data):
-        """
-        """
         log.msg('request_shell')
         pf = _ProtocolFactory(self.client.transport)
         ep = endpoints.SSHShellClientEndpoint.newConnection(reactor, self.user, self.host,
@@ -241,19 +213,13 @@ class ProxySSHSession(channel.CowrieSSHChannel):
         return 1
 
     def extReceived(self, dataType, data):
-        """
-        """
         log.msg('weird extended data: {}'.format(dataType))
 
     def request_agent(self, data):
-        """
-        """
         log.msg('request_agent: {}'.format(repr(data),))
         return 0
 
     def request_x11_req(self, data):
-        """
-        """
         log.msg('request_x11: %s' % (repr(data),))
         return 0
 
@@ -271,13 +237,9 @@ class ProxySSHSession(channel.CowrieSSHChannel):
         self.client = None
 
     def channelClosed(self):
-        """
-        """
         log.msg("Called channelClosed in SSHSession")
 
     def closeReceived(self):
-        """
-        """
         log.msg("closeReceived")
 
     def sendEOF(self):
@@ -293,8 +255,6 @@ class ProxySSHSession(channel.CowrieSSHChannel):
         self.client.transport.write(data)
 
     def eofReceived(self):
-        """
-        """
         log.msg("RECEIVED EOF")
         return
         if self.client:

--- a/src/cowrie/python/logfile.py
+++ b/src/cowrie/python/logfile.py
@@ -2,14 +2,9 @@
 # Copyright (c) 2017 Michel Oosterhof <michel@oosterhof.net>
 # See the COPYRIGHT file for more information
 
-"""
-This module contains
-"""
-
 from __future__ import division, absolute_import
 
 from configparser import NoOptionError
-
 from twisted.logger import textFileLogObserver
 from twisted.python import logfile
 
@@ -33,8 +28,6 @@ class CowrieDailyLogFile(logfile.DailyLogFile):
 
 
 def logger():
-    """
-    """
     try:
         dir = CONFIG.get("honeypot", "log_path")
     except NoOptionError:

--- a/src/cowrie/shell/avatar.py
+++ b/src/cowrie/shell/avatar.py
@@ -1,32 +1,24 @@
 # Copyright (c) 2009-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-"""
-This module contains ...
-"""
-
 from __future__ import division, absolute_import
-
-from zope.interface import implementer
 
 from twisted.conch import avatar
 from twisted.conch.interfaces import IConchUser, ISession, ISFTPServer
 from twisted.conch.ssh import filetransfer as conchfiletransfer
 from twisted.python import log, components
-
-from cowrie.ssh import session as sshsession
-from cowrie.ssh import forwarding
-from cowrie.shell import session as shellsession
-from cowrie.shell import pwd
-from cowrie.shell import filetransfer
+from zope.interface import implementer
 
 from cowrie.core.config import CONFIG
+from cowrie.shell import filetransfer
+from cowrie.shell import pwd
+from cowrie.shell import session as shellsession
+from cowrie.ssh import forwarding
+from cowrie.ssh import session as sshsession
 
 
 @implementer(IConchUser)
 class CowrieUser(avatar.ConchUser):
-    """
-    """
 
     def __init__(self, username, server):
         avatar.ConchUser.__init__(self)
@@ -61,8 +53,6 @@ class CowrieUser(avatar.ConchUser):
             pass
 
     def logout(self):
-        """
-        """
         log.msg("avatar {} logging out".format(self.username))
 
 

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -10,14 +10,14 @@ from __future__ import division, absolute_import
 import os
 import re
 import stat
-import time
 import sys
+import time
 
-from twisted.python import log, failure
 from twisted.internet import error
+from twisted.python import log, failure
 
-from cowrie.shell import fs
 from cowrie.core.config import CONFIG
+from cowrie.shell import fs
 
 # From Python3.6 we get the new shlex version
 if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
@@ -95,8 +95,6 @@ class HoneyPotCommand(object):
         return self.errorWritefn(data.encode('utf8'))
 
     def check_arguments(self, application, args):
-        """
-        """
         files = []
         for arg in args:
             path = self.fs.resolve_path(arg, self.protocol.cwd)
@@ -107,33 +105,23 @@ class HoneyPotCommand(object):
         return files
 
     def set_input_data(self, data):
-        """
-        """
         self.input_data = data
 
     def write_to_file(self, data):
-        """
-        """
         with open(self.safeoutfile, 'ab') as f:
             f.write(data)
         self.writtenBytes += len(data)
         self.fs.update_size(self.outfile, self.writtenBytes)
 
     def write_to_failed(self, data):
-        """
-        """
         pass
 
     def start(self):
-        """
-        """
         if self.write != self.write_to_failed:
             self.call()
         self.exit()
 
     def call(self):
-        """
-        """
         self.write(b'Hello World! [%s]\n' % (repr(self.args),))
 
     def exit(self):
@@ -159,33 +147,23 @@ class HoneyPotCommand(object):
                 pass
 
     def handle_CTRL_C(self):
-        """
-        """
         log.msg('Received CTRL-C, exiting..')
         self.write('^C\n')
         self.exit()
 
     def lineReceived(self, line):
-        """
-        """
         log.msg('QUEUED INPUT: {}'.format(line))
         # FIXME: naive command parsing, see lineReceived below
         line = "".join(line)
         self.protocol.cmdstack[0].cmdpending.append(shlex.split(line, posix=False))
 
     def resume(self):
-        """
-        """
         pass
 
     def handle_TAB(self):
-        """
-        """
         pass
 
     def handle_CTRL_D(self):
-        """
-        """
         pass
 
     def __repr__(self):

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -1,10 +1,6 @@
 # Copyright (c) 2009-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-"""
-This module contains ...
-"""
-
 from __future__ import division, absolute_import
 
 try:
@@ -75,8 +71,6 @@ class FileNotFound(Exception):
 
 
 class HoneyPotFilesystem(object):
-    """
-    """
 
     def __init__(self, fs, arch):
         self.fs = fs
@@ -202,8 +196,7 @@ class HoneyPotFilesystem(object):
             return True
 
     def update_realfile(self, f, realfile):
-        """
-        """
+
         if not f[A_REALFILE] and os.path.exists(realfile) and \
                 not os.path.islink(realfile) and os.path.isfile(realfile) and \
                 f[A_SIZE] < 25000000:
@@ -264,8 +257,6 @@ class HoneyPotFilesystem(object):
             return open(CONFIG.get('honeypot', 'share_path') + '/arch/' + self.arch, 'rb').read()
 
     def mkfile(self, path, uid, gid, size, mode, ctime=None):
-        """
-        """
         if self.newcount > 10000:
             return False
         if ctime is None:
@@ -279,8 +270,6 @@ class HoneyPotFilesystem(object):
         return True
 
     def mkdir(self, path, uid, gid, size, mode, ctime=None):
-        """
-        """
         if self.newcount > 10000:
             raise OSError(errno.EDQUOT, os.strerror(errno.EDQUOT), path)
         if ctime is None:
@@ -378,19 +367,13 @@ class HoneyPotFilesystem(object):
         return None
 
     def read(self, fd, size):
-        """
-        """
         # this should not be called, we intercept at readChunk
         raise NotImplementedError
 
     def write(self, fd, string):
-        """
-        """
         return os.write(fd, string)
 
     def close(self, fd):
-        """
-        """
         if not fd:
             return True
         if self.tempfiles[fd] is not None:
@@ -411,8 +394,6 @@ class HoneyPotFilesystem(object):
         return os.close(fd)
 
     def lseek(self, fd, offset, whence):
-        """
-        """
         if not fd:
             return True
         return os.lseek(fd, offset, whence)
@@ -427,8 +408,6 @@ class HoneyPotFilesystem(object):
         self.mkdir(path, 0, 0, 4096, 16877)
 
     def rmdir(self, path):
-        """
-        """
         path = path.rstrip('/')
         name = os.path.basename(path)
         parent = os.path.dirname(path)
@@ -447,24 +426,18 @@ class HoneyPotFilesystem(object):
         return False
 
     def utime(self, path, atime, mtime):
-        """
-        """
         p = self.getfile(path)
         if p == False:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
         p[A_CTIME] = mtime
 
     def chmod(self, path, perm):
-        """
-        """
         p = self.getfile(path)
         if p == False:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
         p[A_MODE] = stat.S_IFMT(p[A_MODE]) | perm
 
     def chown(self, path, uid, gid):
-        """
-        """
         p = self.getfile(path)
         if p == False:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
@@ -474,8 +447,6 @@ class HoneyPotFilesystem(object):
             p[A_GID] = gid
 
     def remove(self, path):
-        """
-        """
         p = self.getfile(path, follow_symlinks=False)
         if p == False:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
@@ -483,8 +454,6 @@ class HoneyPotFilesystem(object):
         return
 
     def readlink(self, path):
-        """
-        """
         p = self.getfile(path, follow_symlinks=False)
         if p == False:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
@@ -493,13 +462,9 @@ class HoneyPotFilesystem(object):
         return p[A_TARGET]
 
     def symlink(self, targetPath, linkPath):
-        """
-        """
         raise NotImplementedError
 
     def rename(self, oldpath, newpath):
-        """
-        """
         old = self.getfile(oldpath)
         if old == False:
             raise OSError(errno.ENOENT, os.strerror(errno.ENOENT))
@@ -513,19 +478,13 @@ class HoneyPotFilesystem(object):
         return
 
     def listdir(self, path):
-        """
-        """
         names = [x[A_NAME] for x in self.get_path(path)]
         return names
 
     def lstat(self, path):
-        """
-        """
         return self.stat(path, follow_symlinks=False)
 
     def stat(self, path, follow_symlinks=True):
-        """
-        """
         if (path == "/"):
             p = {
                 A_TYPE: T_DIR,
@@ -544,13 +503,9 @@ class HoneyPotFilesystem(object):
         return _statobj(p[A_MODE], 0, 0, 1, p[A_UID], p[A_GID], p[A_SIZE], p[A_CTIME], p[A_CTIME], p[A_CTIME])
 
     def realpath(self, path):
-        """
-        """
         return path
 
     def update_size(self, filename, size):
-        """
-        """
         f = self.getfile(filename)
         if f == False:
             return

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -1,19 +1,15 @@
 # Copyright (c) 2009-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-"""
-This module contains ...
-"""
-
 from __future__ import division, absolute_import
 
+import copy
 import os
 import re
-import copy
 import sys
 
-from twisted.python import log, failure
 from twisted.internet import error
+from twisted.python import log, failure
 
 from cowrie.shell import fs
 
@@ -25,8 +21,6 @@ else:
 
 
 class HoneyPotShell(object):
-    """
-    """
 
     def __init__(self, protocol, interactive=True):
         self.protocol = protocol
@@ -37,8 +31,6 @@ class HoneyPotShell(object):
         self.showPrompt()
 
     def lineReceived(self, line):
-        """
-        """
         log.msg(eventid='cowrie.command.input', input=line, format='CMD: %(input)s')
         self.lexer = shlex.shlex(instream=line, punctuation_chars=True)
         # Add these special characters that are not in the default lexer
@@ -114,8 +106,6 @@ class HoneyPotShell(object):
             self.showPrompt()
 
     def runCommand(self):
-        """
-        """
         pp = None
 
         def runOrPrompt():
@@ -125,8 +115,6 @@ class HoneyPotShell(object):
                 self.showPrompt()
 
         def parse_arguments(arguments):
-            """
-            """
             parsed_arguments = []
             for arg in arguments:
                 parsed_arguments.append(arg)
@@ -225,15 +213,11 @@ class HoneyPotShell(object):
             self.protocol.call_command(pp, cmdclass, *cmd_array[0]['rargs'])
 
     def resume(self):
-        """
-        """
         if self.interactive:
             self.protocol.setInsertMode()
         self.runCommand()
 
     def showPrompt(self):
-        """
-        """
         if not self.interactive:
             return
 
@@ -264,16 +248,12 @@ class HoneyPotShell(object):
             self.cmdstack[-1].handle_CTRL_D()
 
     def handle_CTRL_C(self):
-        """
-        """
         self.protocol.lineBuffer = []
         self.protocol.lineBufferIndex = 0
         self.protocol.terminal.write(b'\n')
         self.showPrompt()
 
     def handle_CTRL_D(self):
-        """
-        """
         log.msg('Received CTRL-D, exiting..')
 
         cmdclass = self.protocol.commands['exit']
@@ -281,8 +261,6 @@ class HoneyPotShell(object):
         self.protocol.call_command(pp, self.protocol.commands['exit'])
 
     def handle_TAB(self):
-        """
-        """
         if not self.protocol.lineBuffer:
             return
         l = ''.join(self.protocol.lineBuffer)
@@ -371,8 +349,7 @@ class StdOutStdErrEmulationProtocol(object):
         self.protocol = protocol
 
     def connectionMade(self):
-        """
-        """
+
         self.input_data = None
 
     def outReceived(self, data):
@@ -402,15 +379,11 @@ class StdOutStdErrEmulationProtocol(object):
         self.next_command = command
 
     def errReceived(self, data):
-        """
-        """
         if self.protocol and self.protocol.terminal:
             self.protocol.terminal.write(data)
         self.err_data = self.err_data + data
 
     def inConnectionLost(self):
-        """
-        """
         pass
 
     def outConnectionLost(self):
@@ -425,16 +398,10 @@ class StdOutStdErrEmulationProtocol(object):
             self.protocol.call_command(self.next_command, npcmd, *npcmdargs)
 
     def errConnectionLost(self):
-        """
-        """
         pass
 
     def processExited(self, reason):
-        """
-        """
         log.msg("processExited for %s, status %d" % (self.cmd, reason.value.exitCode))
 
     def processEnded(self, reason):
-        """
-        """
         log.msg("processEnded for %s, status %d" % (self.cmd, reason.value.exitCode))

--- a/src/cowrie/shell/pwd.py
+++ b/src/cowrie/shell/pwd.py
@@ -26,10 +26,6 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-"""
-This module contains ...
-"""
-
 from __future__ import division, absolute_import
 
 from cowrie.core.config import CONFIG

--- a/src/cowrie/shell/server.py
+++ b/src/cowrie/shell/server.py
@@ -26,22 +26,17 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-"""
-This module contains ...
-"""
-
 from __future__ import division, absolute_import
 
 import copy
-import random
 import json
-
-from configparser import NoOptionError
+import random
 
 import twisted.python.log as log
+from configparser import NoOptionError
 
-from cowrie.shell import fs
 from cowrie.core.config import CONFIG
+from cowrie.shell import fs
 
 
 class CowrieServer(object):

--- a/src/cowrie/shell/session.py
+++ b/src/cowrie/shell/session.py
@@ -1,26 +1,19 @@
 # Copyright (c) 2009-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-"""
-This module contains ...
-"""
-
 from __future__ import division, absolute_import
 
-from zope.interface import implementer
-
-from twisted.python import log
 from twisted.conch.interfaces import ISession
 from twisted.conch.ssh import session
+from twisted.python import log
+from zope.interface import implementer
 
-from cowrie.shell import protocol
 from cowrie.insults import insults
+from cowrie.shell import protocol
 
 
 @implementer(ISession)
 class SSHSessionForCowrieUser(object):
-    """
-    """
 
     def __init__(self, avatar, reactor=None):
         """
@@ -50,16 +43,12 @@ class SSHSessionForCowrieUser(object):
         self.server.initFileSystem()
 
     def openShell(self, processprotocol):
-        """
-        """
         self.protocol = insults.LoggingServerProtocol(
             protocol.HoneyPotInteractiveProtocol, self)
         self.protocol.makeConnection(processprotocol)
         processprotocol.makeConnection(session.wrapProtocol(self.protocol))
 
     def getPty(self, terminal, windowSize, attrs):
-        """
-        """
         self.environ['TERM'] = terminal
         log.msg(
             eventid='cowrie.client.size',
@@ -71,8 +60,6 @@ class SSHSessionForCowrieUser(object):
         return None
 
     def execCommand(self, processprotocol, cmd):
-        """
-        """
         self.protocol = insults.LoggingServerProtocol(
             protocol.HoneyPotExecProtocol, self, cmd)
         self.protocol.makeConnection(processprotocol)
@@ -88,12 +75,8 @@ class SSHSessionForCowrieUser(object):
             self.protocol = None
 
     def eofReceived(self):
-        """
-        """
         if self.protocol:
             self.protocol.eofReceived()
 
     def windowChanged(self, windowSize):
-        """
-        """
         self.windowSize = windowSize

--- a/src/cowrie/shell/shlex.py
+++ b/src/cowrie/shell/shlex.py
@@ -15,14 +15,16 @@ import os
 import re
 import sys
 from collections import deque
-
 from io import StringIO
+
 
 __all__ = ["shlex", "split", "quote"]
 
 
 class shlex:
-    "A lexical analyzer class for simple shell-like syntaxes."
+    """
+    A lexical analyzer class for simple shell-like syntaxes.
+    """
     def __init__(self, instream=None, infile=None, posix=False,
                  punctuation_chars=False):
         if instream is not None:
@@ -78,7 +80,9 @@ class shlex:
                                                        self.lineno))
 
     def push_token(self, tok):
-        "Push a token onto the stack popped by the get_token method"
+        """
+        Push a token onto the stack popped by the get_token method" \
+        """
         if self.debug >= 1:
             print("shlex: pushing token " + repr(tok))
         self.pushback.appendleft(tok)
@@ -98,7 +102,9 @@ class shlex:
                 print('shlex: pushing to stream %s' % (self.instream,))
 
     def pop_source(self):
-        "Pop the input source stack."
+        """
+        Pop the input source stack.
+        """
         self.instream.close()
         (self.infile, self.instream, self.lineno) = self.filestack.popleft()
         if self.debug:
@@ -107,7 +113,9 @@ class shlex:
         self.state = ' '
 
     def get_token(self):
-        "Get a token from the input stream (or from stack if it's nonempty)"
+        """
+        Get a token from the input stream (or from stack if it's nonempty)
+        """
         if self.pushback:
             tok = self.pushback.popleft()
             if self.debug >= 1:
@@ -323,7 +331,9 @@ _find_unsafe = re.compile(r'[^\w@%+=:,./-]').search
 
 
 def quote(s):
-    """Return a shell-escaped version of the string *s*."""
+    """
+    Return a shell-escaped version of the string *s*.
+    """
     if not s:
         return "''"
     if _find_unsafe(s) is None:

--- a/src/cowrie/ssh/channel.py
+++ b/src/cowrie/ssh/channel.py
@@ -9,10 +9,10 @@ and session size limiting
 from __future__ import division, absolute_import
 
 import time
-from configparser import NoOptionError
 
-from twisted.python import log
+from configparser import NoOptionError
 from twisted.conch.ssh import channel
+from twisted.python import log
 
 from cowrie.core import ttylog
 from cowrie.core.config import CONFIG
@@ -58,8 +58,6 @@ class CowrieSSHChannel(channel.SSHChannel):
         channel.SSHChannel.__init__(self, *args, **kw)
 
     def channelOpen(self, specificData):
-        """
-        """
         self.startTime = time.time()
         self.ttylogFile = '%s/tty/%s-%s-%s.log' % (self.ttylogPath, time.strftime('%Y%m%d-%H%M%S'),
                                                    self.conn.transport.transportId, self.id)
@@ -70,8 +68,6 @@ class CowrieSSHChannel(channel.SSHChannel):
         channel.SSHChannel.channelOpen(self, specificData)
 
     def closed(self):
-        """
-        """
         log.msg(eventid='cowrie.log.closed',
                 format="Closing TTY Log: %(ttylog)s after %(duration)d seconds",
                 ttylog=self.ttylogFile,

--- a/src/cowrie/ssh/connection.py
+++ b/src/cowrie/ssh/connection.py
@@ -35,8 +35,8 @@ from __future__ import division, absolute_import
 import struct
 
 from twisted.conch.ssh import connection, common
-from twisted.python import log
 from twisted.internet import defer
+from twisted.python import log
 
 MSG_CHANNEL_SUCCESS = 99
 

--- a/src/cowrie/ssh/factory.py
+++ b/src/cowrie/ssh/factory.py
@@ -8,19 +8,18 @@ This module contains ...
 from __future__ import division, absolute_import
 
 import time
-from configparser import NoOptionError
 
+from configparser import NoOptionError
+from twisted.conch.openssh_compat import primes
 from twisted.conch.ssh import factory
 from twisted.conch.ssh import keys
 from twisted.python import log
-from twisted.conch.openssh_compat import primes
-
-from cowrie.ssh import connection
-from cowrie.ssh import userauth
-from cowrie.ssh import transport
-from cowrie.ssh import keys as cowriekeys
 
 from cowrie.core.config import CONFIG
+from cowrie.ssh import connection
+from cowrie.ssh import keys as cowriekeys
+from cowrie.ssh import transport
+from cowrie.ssh import userauth
 
 
 class CowrieSSHFactory(factory.SSHFactory):
@@ -50,8 +49,6 @@ class CowrieSSHFactory(factory.SSHFactory):
             output.logDispatch(*msg, **args)
 
     def startFactory(self):
-        """
-        """
         # For use by the uptime command
         self.starttime = time.time()
 
@@ -84,8 +81,6 @@ class CowrieSSHFactory(factory.SSHFactory):
         log.msg("Ready to accept SSH connections")
 
     def stopFactory(self):
-        """
-        """
         factory.SSHFactory.stopFactory(self)
 
     def buildProtocol(self, addr):

--- a/src/cowrie/ssh/forwarding.py
+++ b/src/cowrie/ssh/forwarding.py
@@ -8,9 +8,8 @@ This module contains code for handling SSH direct-tcpip connection requests
 from __future__ import division, absolute_import
 
 from configparser import NoOptionError
-
-from twisted.python import log
 from twisted.conch.ssh import forwarding
+from twisted.python import log
 
 from cowrie.core.config import CONFIG
 
@@ -104,13 +103,10 @@ class FakeForwardingChannel(forwarding.SSHConnectForwardingChannel):
     name = b'cowrie-discarded-direct-tcpip'
 
     def channelOpen(self, specificData):
-        """
-        """
         pass
 
     def dataReceived(self, data):
-        """
-        """
+
         log.msg(eventid='cowrie.direct-tcpip.data',
                 ormat='discarded direct-tcp forward request to %(dst_ip)s:%(dst_port)s with data %(data)s',
                 dst_ip=self.hostport[0], dst_port=self.hostport[1], data=repr(data))
@@ -141,8 +137,6 @@ class TCPTunnelForwardingChannel(forwarding.SSHConnectForwardingChannel):
         forwarding.SSHConnectForwardingChannel.dataReceived(self, connect_hdr)
 
     def dataReceived(self, data):
-        """
-        """
         log.msg(eventid='cowrie.tunnelproxy-tcpip.data',
                 format='sending via tunnel proxy %(data)s',
                 data=repr(data))

--- a/src/cowrie/ssh/keys.py
+++ b/src/cowrie/ssh/keys.py
@@ -16,8 +16,6 @@ from cowrie.core.config import CONFIG
 
 
 def getRSAKeys():
-    """
-    """
     publicKeyFile = CONFIG.get('ssh', 'rsa_public_key')
     privateKeyFile = CONFIG.get('ssh', 'rsa_private_key')
     if not (os.path.exists(publicKeyFile) and os.path.exists(privateKeyFile)):
@@ -40,8 +38,6 @@ def getRSAKeys():
 
 
 def getDSAKeys():
-    """
-    """
     publicKeyFile = CONFIG.get('ssh', 'dsa_public_key')
     privateKeyFile = CONFIG.get('ssh', 'dsa_private_key')
     if not (os.path.exists(publicKeyFile) and os.path.exists(privateKeyFile)):

--- a/src/cowrie/ssh/session.py
+++ b/src/cowrie/ssh/session.py
@@ -7,9 +7,9 @@ This module contains ...
 
 from __future__ import division, absolute_import
 
-from twisted.python import log
 from twisted.conch.ssh import session
 from twisted.conch.ssh.common import getNS
+from twisted.python import log
 
 
 class HoneyPotSSHSession(session.SSHSession):
@@ -21,8 +21,6 @@ class HoneyPotSSHSession(session.SSHSession):
         session.SSHSession.__init__(self, *args, **kw)
 
     def request_env(self, data):
-        """
-        """
         name, rest = getNS(data)
         value, rest = getNS(rest)
         if rest:
@@ -35,14 +33,10 @@ class HoneyPotSSHSession(session.SSHSession):
         return 0
 
     def request_agent(self, data):
-        """
-        """
         log.msg("request_agent: {}".format(repr(data)))
         return 0
 
     def request_x11_req(self, data):
-        """
-        """
         log.msg("request_x11: {}".format(repr(data)))
         return 0
 
@@ -75,6 +69,4 @@ class HoneyPotSSHSession(session.SSHSession):
         self.conn.sendClose(self)
 
     def channelClosed(self):
-        """
-        """
         log.msg("Called channelClosed in SSHSession")

--- a/src/cowrie/ssh/transport.py
+++ b/src/cowrie/ssh/transport.py
@@ -10,25 +10,24 @@ RFC 4253.
 from __future__ import division, absolute_import
 
 import re
-import time
 import struct
 import uuid
-from hashlib import md5
+import time
 import zlib
+from hashlib import md5
+
 from configparser import NoOptionError
+from twisted.conch.ssh import transport
+from twisted.conch.ssh.common import getNS
+from twisted.protocols.policies import TimeoutMixin
+from twisted.python import log, randbytes
+from twisted.python.compat import _bytesChr as chr
 
 from cowrie.core.config import CONFIG
 
-from twisted.conch.ssh import transport
-from twisted.python import log, randbytes
-from twisted.conch.ssh.common import getNS
-from twisted.protocols.policies import TimeoutMixin
-from twisted.python.compat import _bytesChr as chr
-
 
 class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
-    """
-    """
+
     startTime = None
     gotVersion = False
     supportedVersions = (b'1.99', b'2.0', b'2.2')
@@ -161,8 +160,6 @@ class HoneyPotSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         self.outgoingPacketSequence += 1
 
     def ssh_KEXINIT(self, packet):
-        """
-        """
         k = getNS(packet[16:], 10)
         strings, _ = k[:-1], k[-1]
         (kexAlgs, keyAlgs, encCS, _, macCS, _, compCS, _, langCS,

--- a/src/cowrie/ssh/userauth.py
+++ b/src/cowrie/ssh/userauth.py
@@ -1,27 +1,20 @@
 # Copyright (c) 2009-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-"""
-This module contains ...
-"""
-
 from __future__ import division, absolute_import
 
 import struct
 
-from twisted.python import log
-from twisted.python.compat import _bytesChr as chr
-from twisted.python.failure import Failure
-from twisted.internet import defer
-
+from twisted.conch import error
 from twisted.conch.interfaces import IConchUser
 from twisted.conch.ssh import userauth
 from twisted.conch.ssh.common import NS, getNS
 from twisted.conch.ssh.transport import DISCONNECT_PROTOCOL_ERROR
-from twisted.conch import error
+from twisted.internet import defer
+from twisted.python.compat import _bytesChr as chr
+from twisted.python.failure import Failure
 
 from cowrie.core import credentials
-
 from cowrie.core.config import CONFIG
 
 
@@ -35,8 +28,6 @@ class HoneyPotSSHUserAuthServer(userauth.SSHUserAuthServer):
     """
 
     def serviceStarted(self):
-        """
-        """
         self.interfaceToMethod[credentials.IUsername] = b'none'
         self.interfaceToMethod[credentials.IUsernamePasswordIP] = b'password'
         self.interfaceToMethod[credentials.IPluggableAuthenticationModulesIP] = b'keyboard-interactive'
@@ -63,8 +54,6 @@ class HoneyPotSSHUserAuthServer(userauth.SSHUserAuthServer):
             userauth.MSG_USERAUTH_BANNER, NS(data) + NS(b'en'))
 
     def ssh_USERAUTH_REQUEST(self, packet):
-        """
-        """
         self.sendBanner()
         return userauth.SSHUserAuthServer.ssh_USERAUTH_REQUEST(self, packet)
 

--- a/src/cowrie/telnet/session.py
+++ b/src/cowrie/telnet/session.py
@@ -9,21 +9,18 @@ from __future__ import division, absolute_import
 
 import traceback
 
-from zope.interface import implementer
-
-from twisted.internet import interfaces, protocol
-from twisted.python import log
 from twisted.conch.ssh import session
 from twisted.conch.telnet import ECHO, SGA, TelnetBootstrapProtocol
+from twisted.internet import interfaces, protocol
+from twisted.python import log
+from zope.interface import implementer
 
-from cowrie.shell import pwd
-from cowrie.shell import protocol as cproto
 from cowrie.insults import insults
+from cowrie.shell import protocol as cproto
+from cowrie.shell import pwd
 
 
 class HoneyPotTelnetSession(TelnetBootstrapProtocol):
-    """
-    """
 
     id = 0  # telnet can only have 1 simultaneous session, unlike SSH
     windowSize = [40, 80]
@@ -82,16 +79,12 @@ class HoneyPotTelnetSession(TelnetBootstrapProtocol):
             log.msg(traceback.format_exc())
 
     def connectionLost(self, reason):
-        """
-        """
         TelnetBootstrapProtocol.connectionLost(self, reason)
         self.server = None
         self.avatar = None
         self.protocol = None
 
     def logout(self):
-        """
-        """
         log.msg('avatar {} logging out'.format(self.username))
 
 
@@ -99,7 +92,8 @@ class HoneyPotTelnetSession(TelnetBootstrapProtocol):
 # https://github.com/twisted/twisted/blob/26ad16ab41db5f0f6d2526a891e81bbd3e260247/twisted/conch/ssh/session.py#L186
 @implementer(interfaces.ITransport)
 class TelnetSessionProcessProtocol(protocol.ProcessProtocol):
-    """I am both an L{IProcessProtocol} and an L{ITransport}.
+    """
+    I am both an L{IProcessProtocol} and an L{ITransport}.
     I am a transport to the remote endpoint and a process protocol to the
     local subsystem.
     """
@@ -137,8 +131,8 @@ class TelnetSessionProcessProtocol(protocol.ProcessProtocol):
 
     def processEnded(self, reason=None):
         """
-        # here SSH is doing signal handling, I don't think telnet supports that so
-        # I'm simply going to bail out
+        here SSH is doing signal handling, I don't think telnet supports that so
+        I'm simply going to bail out
         """
         log.msg("Process ended. Telnet Session disconnected: {}".format(reason))
         self.session.loseConnection()

--- a/src/cowrie/test/fake_server.py
+++ b/src/cowrie/test/fake_server.py
@@ -5,11 +5,11 @@
 
 from __future__ import division, absolute_import
 
-import pickle
 import copy
+import pickle
 
-from cowrie.shell import fs
 from cowrie.core.config import CONFIG
+from cowrie.shell import fs
 
 
 class FakeServer:

--- a/src/cowrie/test/fake_transport.py
+++ b/src/cowrie/test/fake_transport.py
@@ -21,18 +21,18 @@ class Container(object):
     transportId = "test-suite"
     id = "test-suite"
 
-    """
-    Fake function for mockup
-    """
     def getPeer(self):
+        """
+        Fake function for mockup
+        """
         self.host = "1.1.1.1"
         self.port = 2222
         return self
 
-    """
-    Fake function for mockup
-    """
     def processEnded(self, reason):
+        """
+        Fake function for mockup
+        """
         pass
 
 

--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -4,17 +4,16 @@
 # See LICENSE for details.
 
 from __future__ import division, absolute_import
+
 import os
 
 from twisted.trial import unittest
 
 from cowrie.shell import protocol
-from cowrie.core import config
 from cowrie.test import fake_server, fake_transport
 
 os.environ["HONEYPOT_DATA_PATH"] = "../data"
 os.environ["HONEYPOT_FILESYSTEM_FILE"] = "../share/cowrie/fs.pickle"
-from cowrie.core.config import CONFIG
 
 PROMPT = b"root@unitTest:~# "
 
@@ -220,25 +219,18 @@ class ShellFileCommandsTests(unittest.TestCase):
 
 
 class ShellPipeCommandsTests(unittest.TestCase):
-    """
-    """
+
     def setUp(self):
-        """
-        """
         self.proto = protocol.HoneyPotInteractiveProtocol(
             fake_server.FakeAvatar(fake_server.FakeServer()))
         self.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
         self.proto.makeConnection(self.tr)
 
     def test_shell_pipe_with_cat_tail(self):
-        """
-        """
         self.proto.lineReceived(b'echo test | tail -n 1\n')
         self.assertEquals(self.tr.value(), PROMPT + b'test\n' + PROMPT)
 
     def test_shell_pipe_with_cat_head(self):
-        """
-        """
         self.proto.lineReceived(b'echo test | head -n 1\n')
         self.assertEquals(self.tr.value(), PROMPT + b'test\n' + PROMPT)
 

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -8,6 +8,7 @@ Tests for general shell interaction and echo command
 """
 
 from __future__ import division, absolute_import
+
 import os
 
 from twisted.trial import unittest
@@ -23,11 +24,8 @@ PROMPT = b"root@unitTest:~# "
 
 
 class ShellEchoCommandTests(unittest.TestCase):
-    """
-    """
+
     def setUp(self):
-        """
-        """
         self.proto = protocol.HoneyPotInteractiveProtocol(fake_server.FakeAvatar(fake_server.FakeServer()))
         self.tr = fake_transport.FakeTransport("1.1.1.1", "1111")
         self.proto.makeConnection(self.tr)

--- a/src/cowrie/test/test_utils.py
+++ b/src/cowrie/test/test_utils.py
@@ -1,9 +1,8 @@
 from __future__ import division, absolute_import
 
-import configparser
-import textwrap
 from io import StringIO
 
+import configparser
 from twisted.application.service import MultiService
 from twisted.internet import protocol, reactor
 from twisted.trial import unittest

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -26,37 +26,29 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-"""
-FIXME: This module contains ...
-"""
-
 from __future__ import print_function, division, absolute_import
-
-from zope.interface import implementer, provider
 
 import os
 import sys
-import configparser
 
+import configparser
 from twisted._version import __version__
-from twisted.python import log, usage
-from twisted.plugin import IPlugin
-from twisted.application.service import IServiceMaker
 from twisted.application import service
+from twisted.application.service import IServiceMaker
 from twisted.cred import portal
 from twisted.internet import reactor
 from twisted.logger import ILogObserver, globalLogPublisher
+from twisted.plugin import IPlugin
+from twisted.python import log, usage
+from zope.interface import implementer, provider
 
-from cowrie.core.config import CONFIG
-
-from cowrie.core.utils import get_endpoints_from_section, create_endpoint_services
-from cowrie import core
-import cowrie.core.realm
 import cowrie.core.checkers
-
-import cowrie.telnet.transport
+import cowrie.core.realm
 import cowrie.ssh.factory
-
+import cowrie.telnet.transport
+from cowrie import core
+from cowrie.core.config import CONFIG
+from cowrie.core.utils import get_endpoints_from_section, create_endpoint_services
 
 if __version__.major < 17:
     raise ImportError("Your version of Twisted is too old. Please ensure your virtual environment is set up correctly.")
@@ -76,8 +68,7 @@ class Options(usage.Options):
 
 @provider(ILogObserver)
 def importFailureObserver(event):
-    """
-    """
+
     if 'failure' in event and event['failure'].type is ImportError:
         log.err("ERROR: %s. Please run `pip install -U -r requirements.txt` "
                 "from Cowrie's install directory and virtualenv to install "
@@ -89,9 +80,6 @@ globalLogPublisher.addObserver(importFailureObserver)
 
 @implementer(IServiceMaker, IPlugin)
 class CowrieServiceMaker(object):
-    """
-    FIXME: Docstring
-    """
     tapname = "cowrie"
     description = "She sells sea shells by the sea shore."
     options = Options


### PR DESCRIPTION
Imports are now pep8 compatible.
Unfortunally there is no check in flake8. So this is a generall work
which has to be done manually.

Imports are now splitted into build-ins, third-party and own code.
Within this groups they are ordered alphabetical and grouped by `import`
and `from` import syntax.

Empty or not usefull docstrings has been removed from the code.
We don't need nonsense documentation eating up space.