### PR TITLE
Improved imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,9 @@ before_install:
 - sudo apt-get -qq update
 install: pip install -r requirements.txt
 before_script:
-    - pip install flake8 twistedchecker  # pytest  # add another testing frameworks later
+    - pip install flake8 flake8-import-order
     # stop the build if there are Python syntax errors or undefined names
-    - flake8 . --count --select=E1,E2,E3,E901,E999,F821,F822,F823 --show-source --statistics
-    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-    # ignore E3xx errors, Twisted has different empty line convention
-    - flake8 . --count --ignore=E3 --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-#    - twistedchecker --pep8=y -d W9001,W9002 cowrie twisted.plugins
-#   Twistedchecker has some version issues, disable for now
+    - flake8 --count --select=E1,E2,E3,E901,E999,F401,F821,F822,F823,I --application-import-names cowrie --max-line-length=120 --statistics .
 script: PYTHONPATH=${TRAVIS_BUILD_DIR}/src trial cowrie
 notifications:
   email: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY src /cowrie
 
 FROM post-builder as linter
 RUN pip install flake8 flake8-import-order && \
-  flake8 --count --select=E1,E2,E3,E901,E999,F401,F821,F822,F823,I --application-import-names cowrie --max-line-length=120 --statistics .
+  flake8 --count --select=E1,E2,E3,E901,E999,F401,F821,F822,F823,I --application-import-names cowrie --max-line-length=120 --statistics /cowrie
 
 FROM post-builder as unittest
 ENV PYTHONPATH=/cowrie

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN pip install -r requirements.txt --no-index --find-links=/root/wheelhouse && 
 COPY src /cowrie
 
 FROM post-builder as linter
-RUN pip install flake8 && \
-  flake8 /cowrie --count --select=E1,E2,E3,E901,E999,F401,F821,F822,F823 --show-source --statistics
+RUN pip install flake8 flake8-import-order && \
+  flake8 --count --select=E1,E2,E3,E901,E999,F401,F821,F822,F823,I --application-import-names cowrie --max-line-length=120 --statistics .
 
 FROM post-builder as unittest
 ENV PYTHONPATH=/cowrie

--- a/bin/createdynamicprocess.py
+++ b/bin/createdynamicprocess.py
@@ -1,5 +1,5 @@
-import json
 import datetime
+import json
 import random
 
 import psutil

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name="Cowrie",

--- a/src/cowrie/commands/adduser.py
+++ b/src/cowrie/commands/adduser.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2010 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import random
 

--- a/src/cowrie/commands/apt.py
+++ b/src/cowrie/commands/apt.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2009 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import random
 import re
 
-from twisted.internet import reactor, defer
+from twisted.internet import defer, reactor
 from twisted.internet.defer import inlineCallbacks
 
 from cowrie.shell.command import HoneyPotCommand

--- a/src/cowrie/commands/base.py
+++ b/src/cowrie/commands/base.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import codecs
 import datetime

--- a/src/cowrie/commands/base64.py
+++ b/src/cowrie/commands/base64.py
@@ -1,4 +1,4 @@
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 

--- a/src/cowrie/commands/busybox.py
+++ b/src/cowrie/commands/busybox.py
@@ -1,6 +1,6 @@
 
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from twisted.python import log
 

--- a/src/cowrie/commands/cat.py
+++ b/src/cowrie/commands/cat.py
@@ -7,7 +7,7 @@ cat command
 TODO: support for '-' (stdin marked as '-')
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 

--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 import hashlib
@@ -10,8 +10,9 @@ import re
 import time
 
 from OpenSSL import SSL
+
 from twisted.internet import reactor, ssl
-from twisted.python import log, compat
+from twisted.python import compat, log
 from twisted.web import client
 
 from cowrie.core.config import CONFIG

--- a/src/cowrie/commands/dd.py
+++ b/src/cowrie/commands/dd.py
@@ -5,7 +5,7 @@
 dd commands
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from twisted.python import log
 

--- a/src/cowrie/commands/du.py
+++ b/src/cowrie/commands/du.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2018 Danilo Vargas <danilo.vargas@csiete.org>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import os
 

--- a/src/cowrie/commands/env.py
+++ b/src/cowrie/commands/env.py
@@ -1,5 +1,5 @@
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from cowrie.shell.command import HoneyPotCommand
 

--- a/src/cowrie/commands/ethtool.py
+++ b/src/cowrie/commands/ethtool.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2014 Peter Reuterås <peter@reuteras.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from cowrie.shell.command import HoneyPotCommand
 

--- a/src/cowrie/commands/free.py
+++ b/src/cowrie/commands/free.py
@@ -5,7 +5,7 @@
 This module ...
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 

--- a/src/cowrie/commands/fs.py
+++ b/src/cowrie/commands/fs.py
@@ -6,7 +6,7 @@
 Filesystem related commands
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import copy
 import getopt

--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Author: Claud Xiao
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import ftplib
 import getopt

--- a/src/cowrie/commands/gcc.py
+++ b/src/cowrie/commands/gcc.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2013 Bas Stottelaar <basstottelaar [AT] gmail [DOT] com>
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 import os

--- a/src/cowrie/commands/ifconfig.py
+++ b/src/cowrie/commands/ifconfig.py
@@ -2,9 +2,9 @@
 # Copyright (c) 2014 Peter Reuterås <peter@reuteras.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
-from random import randrange, randint
+from random import randint, randrange
 
 from cowrie.shell.command import HoneyPotCommand
 

--- a/src/cowrie/commands/iptables.py
+++ b/src/cowrie/commands/iptables.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2013 Bas Stottelaar <basstottelaar [AT] gmail [DOT] com>
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import optparse
 

--- a/src/cowrie/commands/last.py
+++ b/src/cowrie/commands/last.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import time
 

--- a/src/cowrie/commands/ls.py
+++ b/src/cowrie/commands/ls.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 import stat
@@ -9,7 +9,7 @@ import time
 
 import cowrie.shell.fs as fs
 from cowrie.shell.command import HoneyPotCommand
-from cowrie.shell.pwd import Passwd, Group
+from cowrie.shell.pwd import Group, Passwd
 
 commands = {}
 

--- a/src/cowrie/commands/nc.py
+++ b/src/cowrie/commands/nc.py
@@ -1,4 +1,4 @@
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 import re

--- a/src/cowrie/commands/netstat.py
+++ b/src/cowrie/commands/netstat.py
@@ -1,6 +1,6 @@
 # Based on work by Peter Reuteras (https://bitbucket.org/reuteras/kippo/)
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import socket
 

--- a/src/cowrie/commands/nohup.py
+++ b/src/cowrie/commands/nohup.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2014 Peter Reuterås <peter@reuteras.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from cowrie.shell.command import HoneyPotCommand
 

--- a/src/cowrie/commands/perl.py
+++ b/src/cowrie/commands/perl.py
@@ -5,7 +5,7 @@
 This module contains the perl command
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 

--- a/src/cowrie/commands/ping.py
+++ b/src/cowrie/commands/ping.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 import hashlib

--- a/src/cowrie/commands/python.py
+++ b/src/cowrie/commands/python.py
@@ -5,7 +5,7 @@
 This module contains the python commnad
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 

--- a/src/cowrie/commands/scp.py
+++ b/src/cowrie/commands/scp.py
@@ -26,7 +26,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 import hashlib

--- a/src/cowrie/commands/service.py
+++ b/src/cowrie/commands/service.py
@@ -5,7 +5,7 @@
 This module contains the service commnad
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 

--- a/src/cowrie/commands/sleep.py
+++ b/src/cowrie/commands/sleep.py
@@ -5,7 +5,7 @@
 This module contains the sleep command
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from twisted.internet import reactor
 

--- a/src/cowrie/commands/ssh.py
+++ b/src/cowrie/commands/ssh.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 import hashlib

--- a/src/cowrie/commands/sudo.py
+++ b/src/cowrie/commands/sudo.py
@@ -1,6 +1,6 @@
 
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 

--- a/src/cowrie/commands/tar.py
+++ b/src/cowrie/commands/tar.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import os
 import tarfile

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -1,6 +1,6 @@
 #
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import tftpy
 

--- a/src/cowrie/commands/ulimit.py
+++ b/src/cowrie/commands/ulimit.py
@@ -5,7 +5,7 @@
 This module ...
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 

--- a/src/cowrie/commands/uname.py
+++ b/src/cowrie/commands/uname.py
@@ -5,7 +5,7 @@
 uname command
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from configparser import NoOptionError
 

--- a/src/cowrie/commands/uptime.py
+++ b/src/cowrie/commands/uptime.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import time
 

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -1,15 +1,16 @@
 # Copyright (c) 2009 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import getopt
 import os
 import time
 
 from OpenSSL import SSL
+
 from twisted.internet import reactor, ssl
-from twisted.python import log, compat
+from twisted.python import compat, log
 from twisted.web import client
 
 from cowrie.core.artifact import Artifact

--- a/src/cowrie/commands/which.py
+++ b/src/cowrie/commands/which.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2013 Bas Stottelaar <basstottelaar [AT] gmail [DOT] com>
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from cowrie.shell.command import HoneyPotCommand
 

--- a/src/cowrie/commands/yum.py
+++ b/src/cowrie/commands/yum.py
@@ -4,17 +4,16 @@
 
 # Modified by Fabiola Buschendorf, https://github.com/FabiolaBusch
 
-from __future__ import division, absolute_import
-from datetime import datetime
+from __future__ import absolute_import, division
 
+import hashlib
 import random
 import re
-import hashlib
 
-from twisted.internet import reactor, defer
+from twisted.internet import defer, reactor
 from twisted.internet.defer import inlineCallbacks
-
 from twisted.python import log
+
 from cowrie.shell.command import HoneyPotCommand
 
 arch = 'x86_64'

--- a/src/cowrie/core/artifact.py
+++ b/src/cowrie/core/artifact.py
@@ -20,7 +20,7 @@ or:
 
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import hashlib
 import os

--- a/src/cowrie/core/auth.py
+++ b/src/cowrie/core/auth.py
@@ -5,7 +5,7 @@
 This module contains authentication code
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import json
 import re

--- a/src/cowrie/core/cef.py
+++ b/src/cowrie/core/cef.py
@@ -26,7 +26,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 #  cowrie.client.fingerprint
 #  cowrie.client.size

--- a/src/cowrie/core/checkers.py
+++ b/src/cowrie/core/checkers.py
@@ -5,7 +5,7 @@
 This module contains ...
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from sys import modules
 
@@ -15,7 +15,8 @@ from twisted.cred.checkers import ICredentialsChecker
 from twisted.cred.credentials import ISSHPrivateKey
 from twisted.cred.error import UnauthorizedLogin, UnhandledCredentials
 from twisted.internet import defer
-from twisted.python import log, failure
+from twisted.python import failure, log
+
 from zope.interface import implementer
 
 from cowrie.core import auth

--- a/src/cowrie/core/config.py
+++ b/src/cowrie/core/config.py
@@ -5,11 +5,10 @@
 This module contains ...
 """
 
-from __future__ import division, absolute_import
-
-import os
+from __future__ import absolute_import, division
 
 import configparser
+import os
 
 
 def to_environ_key(key):

--- a/src/cowrie/core/credentials.py
+++ b/src/cowrie/core/credentials.py
@@ -26,9 +26,10 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
-from twisted.cred.credentials import IUsernamePassword, ICredentials
+from twisted.cred.credentials import ICredentials, IUsernamePassword
+
 from zope.interface import implementer
 
 

--- a/src/cowrie/core/dblog.py
+++ b/src/cowrie/core/dblog.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import abc
 import re

--- a/src/cowrie/core/output.py
+++ b/src/cowrie/core/output.py
@@ -26,7 +26,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import abc
 import datetime

--- a/src/cowrie/core/realm.py
+++ b/src/cowrie/core/realm.py
@@ -26,12 +26,13 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import twisted
 from twisted.conch import interfaces as conchinterfaces
 from twisted.conch.telnet import ITelnetProtocol
 from twisted.python import log
+
 from zope.interface import implementer
 
 from cowrie.core.config import CONFIG

--- a/src/cowrie/core/ttylog.py
+++ b/src/cowrie/core/ttylog.py
@@ -7,7 +7,7 @@
 Should be compatible with user mode linux
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import hashlib
 import struct

--- a/src/cowrie/core/utils.py
+++ b/src/cowrie/core/utils.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2010-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import sys
 

--- a/src/cowrie/dblog/xmpp.py
+++ b/src/cowrie/dblog/xmpp.py
@@ -1,5 +1,5 @@
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import json
 import uuid
@@ -8,6 +8,7 @@ from twisted.application import service
 from twisted.python import log
 from twisted.words.protocols.jabber import jid
 from twisted.words.protocols.jabber.jid import JID
+
 from wokkel import muc
 from wokkel.client import XMPPClient
 from wokkel.xmppim import AvailablePresence

--- a/src/cowrie/insults/insults.py
+++ b/src/cowrie/insults/insults.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import hashlib
 import os

--- a/src/cowrie/output/csirtg.py
+++ b/src/cowrie/output/csirtg.py
@@ -1,10 +1,11 @@
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import os
 from datetime import datetime
 
 from csirtgsdk.client import Client
 from csirtgsdk.indicator import Indicator
+
 from twisted.python import log
 
 import cowrie.core.output

--- a/src/cowrie/output/cuckoo.py
+++ b/src/cowrie/output/cuckoo.py
@@ -30,7 +30,7 @@
 Send downloaded/uplaoded files to Cuckoo
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import os
 

--- a/src/cowrie/output/dshield.py
+++ b/src/cowrie/output/dshield.py
@@ -3,17 +3,19 @@ Send SSH logins to SANS DShield.
 See https://isc.sans.edu/ssh.html
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import base64
-import dateutil.parser
 import hashlib
 import hmac
 import re
 import time
 
+import dateutil.parser
+
 import requests
-from twisted.internet import threads, reactor
+
+from twisted.internet import reactor, threads
 from twisted.python import log
 
 import cowrie.core.output

--- a/src/cowrie/output/elasticsearch.py
+++ b/src/cowrie/output/elasticsearch.py
@@ -1,6 +1,6 @@
 # Simple elasticsearch logger
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from elasticsearch import Elasticsearch
 

--- a/src/cowrie/output/hpfeeds.py
+++ b/src/cowrie/output/hpfeeds.py
@@ -3,7 +3,7 @@
 Output plugin for HPFeeds
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import hashlib
 import json

--- a/src/cowrie/output/hpfeeds3.py
+++ b/src/cowrie/output/hpfeeds3.py
@@ -3,13 +3,14 @@
 Output plugin for HPFeeds
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import json
 import logging
 
 from hpfeeds.twisted import ClientSessionService
-from twisted.internet import reactor, ssl, endpoints
+
+from twisted.internet import endpoints, reactor, ssl
 from twisted.python import log
 
 import cowrie.core.output

--- a/src/cowrie/output/influx.py
+++ b/src/cowrie/output/influx.py
@@ -2,6 +2,7 @@ import re
 
 from influxdb import InfluxDBClient
 from influxdb.exceptions import InfluxDBClientError
+
 from twisted.python import log
 
 import cowrie.core.output

--- a/src/cowrie/output/jsonlog.py
+++ b/src/cowrie/output/jsonlog.py
@@ -26,7 +26,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import json
 import os

--- a/src/cowrie/output/kafka.py
+++ b/src/cowrie/output/kafka.py
@@ -30,7 +30,7 @@
 Work in progress Kafka output. Not functional yet
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import json
 import logging
@@ -38,8 +38,9 @@ import random
 import string
 
 from afkak.client import KafkaClient
-from afkak.partitioner import RoundRobinPartitioner, HashedPartitioner
+from afkak.partitioner import HashedPartitioner, RoundRobinPartitioner
 from afkak.producer import Producer
+
 from twisted.internet import defer, task
 from twisted.python import log
 

--- a/src/cowrie/output/localsyslog.py
+++ b/src/cowrie/output/localsyslog.py
@@ -26,9 +26,10 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import syslog
+
 import twisted.python.syslog
 
 import cowrie.core.cef

--- a/src/cowrie/output/malshare.py
+++ b/src/cowrie/output/malshare.py
@@ -31,7 +31,7 @@ Send files to https://malshare.com/
 More info https://malshare.com/doc.php
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import os
 

--- a/src/cowrie/output/mongodb.py
+++ b/src/cowrie/output/mongodb.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import pymongo
+
 from twisted.python import log
 
 import cowrie.core.output

--- a/src/cowrie/output/mysql.py
+++ b/src/cowrie/output/mysql.py
@@ -3,9 +3,10 @@
 MySQL output connector. Writes audit logs to MySQL database
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import MySQLdb
+
 from twisted.enterprise import adbapi
 from twisted.internet import defer
 from twisted.python import log

--- a/src/cowrie/output/redis.py
+++ b/src/cowrie/output/redis.py
@@ -1,9 +1,9 @@
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import json
+from ConfigParser import NoOptionError
 
 import redis
-from ConfigParser import NoOptionError
 
 import cowrie.core.output
 from cowrie.core.config import CONFIG

--- a/src/cowrie/output/rethinkdblog.py
+++ b/src/cowrie/output/rethinkdblog.py
@@ -1,4 +1,4 @@
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import time
 from datetime import datetime

--- a/src/cowrie/output/s3.py
+++ b/src/cowrie/output/s3.py
@@ -2,11 +2,13 @@
 Send downloaded/uplaoded files to S3 (or compatible)
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
+
+from configparser import NoOptionError
 
 from botocore.exceptions import ClientError
 from botocore.session import get_session
-from configparser import NoOptionError
+
 from twisted.internet import defer, threads
 from twisted.python import log
 

--- a/src/cowrie/output/slack.py
+++ b/src/cowrie/output/slack.py
@@ -26,7 +26,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import json
 import time

--- a/src/cowrie/output/socketlog.py
+++ b/src/cowrie/output/socketlog.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import json
 import socket

--- a/src/cowrie/output/splunk.py
+++ b/src/cowrie/output/splunk.py
@@ -6,7 +6,7 @@ Not ready for production use.
 JSON log file is still recommended way to go
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import json
 from StringIO import StringIO

--- a/src/cowrie/output/splunklegacy.py
+++ b/src/cowrie/output/splunklegacy.py
@@ -10,7 +10,7 @@ required then
 
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import json
 

--- a/src/cowrie/output/sqlite.py
+++ b/src/cowrie/output/sqlite.py
@@ -1,4 +1,4 @@
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import sqlite3
 

--- a/src/cowrie/output/textlog.py
+++ b/src/cowrie/output/textlog.py
@@ -26,7 +26,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import cowrie.core.cef
 import cowrie.core.output

--- a/src/cowrie/output/virustotal.py
+++ b/src/cowrie/output/virustotal.py
@@ -31,7 +31,7 @@ Send SSH logins to Virustotal
 Work in Progress - not functional yet
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import json
 import os
@@ -42,11 +42,12 @@ except ImportError:
     from urllib import urlencode
     from urlparse import urlparse
 
-from twisted.python import log
-from twisted.web.iweb import IBodyProducer
 from twisted.internet import defer, reactor
-from twisted.web import client, http_headers
 from twisted.internet.ssl import ClientContextFactory
+from twisted.python import log
+from twisted.web import client, http_headers
+from twisted.web.iweb import IBodyProducer
+
 from zope.interface import implementer
 
 import cowrie.core.output

--- a/src/cowrie/output/xmpp.py
+++ b/src/cowrie/output/xmpp.py
@@ -1,5 +1,5 @@
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import json
 import string
@@ -9,6 +9,7 @@ from twisted.application import service
 from twisted.python import log
 from twisted.words.protocols.jabber import jid
 from twisted.words.protocols.jabber.jid import JID
+
 from wokkel import muc
 from wokkel.client import XMPPClient
 from wokkel.xmppim import AvailablePresence

--- a/src/cowrie/proxy/avatar.py
+++ b/src/cowrie/proxy/avatar.py
@@ -5,12 +5,14 @@
 This module contains ...
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from configparser import NoOptionError
+
 from twisted.conch import avatar
 from twisted.conch.interfaces import IConchUser, ISession
-from twisted.python import log, components
+from twisted.python import components, log
+
 from zope.interface import implementer
 
 from cowrie.core.config import CONFIG

--- a/src/cowrie/proxy/endpoints.py
+++ b/src/cowrie/proxy/endpoints.py
@@ -22,7 +22,7 @@ from twisted.conch.ssh.keys import Key
 from twisted.conch.ssh.session import SSHSession, packRequest_pty_req
 from twisted.conch.ssh.transport import SSHClientTransport
 from twisted.conch.ssh.userauth import SSHUserAuthClient
-from twisted.internet.defer import Deferred, succeed, CancelledError
+from twisted.internet.defer import CancelledError, Deferred, succeed
 from twisted.internet.endpoints import TCP4ClientEndpoint, connectProtocol
 from twisted.internet.error import ConnectionDone, ProcessTerminated
 from twisted.internet.interfaces import IStreamClientEndpoint
@@ -31,6 +31,7 @@ from twisted.python import log
 from twisted.python.compat import nativeString, networkString
 from twisted.python.failure import Failure
 from twisted.python.filepath import FilePath
+
 from zope.interface import Interface, implementer
 
 

--- a/src/cowrie/proxy/server.py
+++ b/src/cowrie/proxy/server.py
@@ -26,7 +26,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from cowrie.core.config import CONFIG
 

--- a/src/cowrie/proxy/session.py
+++ b/src/cowrie/proxy/session.py
@@ -1,13 +1,14 @@
 # Copyright (c) 2017 Michel Oosterhof <michel@oosterhof.net>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from configparser import NoOptionError
+
 from twisted.conch.client.knownhosts import KnownHostsFile
 from twisted.conch.ssh import common, keys, session
 from twisted.conch.ssh.common import getNS
-from twisted.internet import reactor, protocol
+from twisted.internet import protocol, reactor
 from twisted.python import log
 
 from cowrie.core.config import CONFIG

--- a/src/cowrie/python/logfile.py
+++ b/src/cowrie/python/logfile.py
@@ -2,9 +2,10 @@
 # Copyright (c) 2017 Michel Oosterhof <michel@oosterhof.net>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from configparser import NoOptionError
+
 from twisted.logger import textFileLogObserver
 from twisted.python import logfile
 

--- a/src/cowrie/shell/avatar.py
+++ b/src/cowrie/shell/avatar.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2009-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from twisted.conch import avatar
-from twisted.conch.interfaces import IConchUser, ISession, ISFTPServer
+from twisted.conch.interfaces import IConchUser, ISFTPServer, ISession
 from twisted.conch.ssh import filetransfer as conchfiletransfer
-from twisted.python import log, components
+from twisted.python import components, log
+
 from zope.interface import implementer
 
 from cowrie.core.config import CONFIG

--- a/src/cowrie/shell/command.py
+++ b/src/cowrie/shell/command.py
@@ -5,7 +5,7 @@
 This module contains code to run a command
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import os
 import re
@@ -14,7 +14,7 @@ import sys
 import time
 
 from twisted.internet import error
-from twisted.python import log, failure
+from twisted.python import failure, log
 
 from cowrie.core.config import CONFIG
 from cowrie.shell import fs

--- a/src/cowrie/shell/customparser.py
+++ b/src/cowrie/shell/customparser.py
@@ -1,4 +1,4 @@
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import argparse
 

--- a/src/cowrie/shell/filetransfer.py
+++ b/src/cowrie/shell/filetransfer.py
@@ -5,18 +5,19 @@
 This module contains ...
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import os
+from configparser import NoOptionError
 
 import twisted
 import twisted.conch.ls
-from configparser import NoOptionError
 from twisted.conch.interfaces import ISFTPFile, ISFTPServer
 from twisted.conch.ssh import filetransfer
-from twisted.conch.ssh.filetransfer import FXF_READ, FXF_WRITE, FXF_APPEND, FXF_CREAT, FXF_TRUNC, FXF_EXCL
+from twisted.conch.ssh.filetransfer import FXF_APPEND, FXF_CREAT, FXF_EXCL, FXF_READ, FXF_TRUNC, FXF_WRITE
 from twisted.python import log
 from twisted.python.compat import nativeString
+
 from zope.interface import implementer
 
 import cowrie.shell.pwd as pwd

--- a/src/cowrie/shell/fs.py
+++ b/src/cowrie/shell/fs.py
@@ -1,20 +1,21 @@
 # Copyright (c) 2009-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 try:
     import cPickle as pickle
 except:
     import pickle
 
-import os
-import time
+import errno
 import fnmatch
 import hashlib
+import os
 import re
 import stat
-import errno
+import time
+
 
 from twisted.python import log
 

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import copy
 import os
@@ -9,7 +9,7 @@ import re
 import sys
 
 from twisted.internet import error
-from twisted.python import log, failure
+from twisted.python import failure, log
 
 from cowrie.shell import fs
 

--- a/src/cowrie/shell/protocol.py
+++ b/src/cowrie/shell/protocol.py
@@ -2,13 +2,13 @@
 # Copyright (c) 2009-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import os
 import socket
-import traceback
 import sys
 import time
+import traceback
 
 from twisted.conch import recvline
 from twisted.conch.insults import insults

--- a/src/cowrie/shell/pwd.py
+++ b/src/cowrie/shell/pwd.py
@@ -26,7 +26,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from cowrie.core.config import CONFIG
 

--- a/src/cowrie/shell/server.py
+++ b/src/cowrie/shell/server.py
@@ -26,14 +26,14 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import copy
 import json
 import random
+from configparser import NoOptionError
 
 import twisted.python.log as log
-from configparser import NoOptionError
 
 from cowrie.core.config import CONFIG
 from cowrie.shell import fs

--- a/src/cowrie/shell/session.py
+++ b/src/cowrie/shell/session.py
@@ -1,11 +1,12 @@
 # Copyright (c) 2009-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from twisted.conch.interfaces import ISession
 from twisted.conch.ssh import session
 from twisted.python import log
+
 from zope.interface import implementer
 
 from cowrie.insults import insults

--- a/src/cowrie/shell/shlex.py
+++ b/src/cowrie/shell/shlex.py
@@ -9,7 +9,7 @@
 # iterator interface by Gustavo Niemeyer, April 2003.
 # changes to tokenize more like Posix shells by Vinay Sajip, January 2012.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import os
 import re

--- a/src/cowrie/ssh/channel.py
+++ b/src/cowrie/ssh/channel.py
@@ -6,11 +6,11 @@ This module contains a subclass of SSHChannel with additional logging
 and session size limiting
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import time
-
 from configparser import NoOptionError
+
 from twisted.conch.ssh import channel
 from twisted.python import log
 

--- a/src/cowrie/ssh/connection.py
+++ b/src/cowrie/ssh/connection.py
@@ -30,11 +30,11 @@
 This module contains connection code to work around issues with the
 Granados SSH client library.
 """
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import struct
 
-from twisted.conch.ssh import connection, common
+from twisted.conch.ssh import common, connection
 from twisted.internet import defer
 from twisted.python import log
 

--- a/src/cowrie/ssh/factory.py
+++ b/src/cowrie/ssh/factory.py
@@ -5,11 +5,11 @@
 This module contains ...
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import time
-
 from configparser import NoOptionError
+
 from twisted.conch.openssh_compat import primes
 from twisted.conch.ssh import factory
 from twisted.conch.ssh import keys

--- a/src/cowrie/ssh/forwarding.py
+++ b/src/cowrie/ssh/forwarding.py
@@ -5,9 +5,10 @@
 This module contains code for handling SSH direct-tcpip connection requests
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from configparser import NoOptionError
+
 from twisted.conch.ssh import forwarding
 from twisted.python import log
 

--- a/src/cowrie/ssh/keys.py
+++ b/src/cowrie/ssh/keys.py
@@ -5,7 +5,7 @@
 This module contains ...
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import os
 

--- a/src/cowrie/ssh/session.py
+++ b/src/cowrie/ssh/session.py
@@ -5,7 +5,7 @@
 This module contains ...
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from twisted.conch.ssh import session
 from twisted.conch.ssh.common import getNS

--- a/src/cowrie/ssh/transport.py
+++ b/src/cowrie/ssh/transport.py
@@ -7,16 +7,16 @@ encryption and the compression. The transport layer is described in
 RFC 4253.
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import re
 import struct
-import uuid
 import time
+import uuid
 import zlib
+from configparser import NoOptionError
 from hashlib import md5
 
-from configparser import NoOptionError
 from twisted.conch.ssh import transport
 from twisted.conch.ssh.common import getNS
 from twisted.protocols.policies import TimeoutMixin

--- a/src/cowrie/ssh/userauth.py
+++ b/src/cowrie/ssh/userauth.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2009-2014 Upi Tamminen <desaster@gmail.com>
 # See the COPYRIGHT file for more information
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import struct
 

--- a/src/cowrie/telnet/session.py
+++ b/src/cowrie/telnet/session.py
@@ -5,7 +5,7 @@ Telnet User Session management for the Honeypot
 @author: Olivier Bilodeau <obilodeau@gosecure.ca>
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import traceback
 
@@ -13,6 +13,7 @@ from twisted.conch.ssh import session
 from twisted.conch.telnet import ECHO, SGA, TelnetBootstrapProtocol
 from twisted.internet import interfaces, protocol
 from twisted.python import log
+
 from zope.interface import implementer
 
 from cowrie.insults import insults

--- a/src/cowrie/telnet/transport.py
+++ b/src/cowrie/telnet/transport.py
@@ -5,15 +5,15 @@ Telnet Transport and Authentication for the Honeypot
 @author: Olivier Bilodeau <obilodeau@gosecure.ca>
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import struct
-import uuid
 import time
-
+import uuid
 from configparser import NoOptionError
-from twisted.conch.telnet import AuthenticatingTelnetProtocol, ECHO, ITelnetProtocol, \
-    SGA, NAWS, LINEMODE, TelnetTransport, AlreadyNegotiating
+
+from twisted.conch.telnet import AlreadyNegotiating, AuthenticatingTelnetProtocol, ITelnetProtocol, TelnetTransport
+from twisted.conch.telnet import ECHO, LINEMODE, NAWS, SGA
 from twisted.internet import protocol
 from twisted.protocols.policies import TimeoutMixin
 from twisted.python import log

--- a/src/cowrie/test/fake_server.py
+++ b/src/cowrie/test/fake_server.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2016 Dave Germiquet
 # See LICENSE for details.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import copy
 import pickle

--- a/src/cowrie/test/fake_transport.py
+++ b/src/cowrie/test/fake_transport.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2016 Dave Germiquet
 # See LICENSE for details.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 from twisted.conch.insults import insults
 from twisted.test import proto_helpers

--- a/src/cowrie/test/test_base_commands.py
+++ b/src/cowrie/test/test_base_commands.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2016 Dave Germiquet
 # See LICENSE for details.
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import os
 

--- a/src/cowrie/test/test_echo.py
+++ b/src/cowrie/test/test_echo.py
@@ -7,7 +7,7 @@
 Tests for general shell interaction and echo command
 """
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
 import os
 

--- a/src/cowrie/test/test_utils.py
+++ b/src/cowrie/test/test_utils.py
@@ -1,13 +1,13 @@
-from __future__ import division, absolute_import
-
-from io import StringIO
+from __future__ import absolute_import, division
 
 import configparser
+from io import StringIO
+
 from twisted.application.service import MultiService
 from twisted.internet import protocol, reactor
 from twisted.trial import unittest
 
-from cowrie.core.utils import durationHuman, get_endpoints_from_section, create_endpoint_services
+from cowrie.core.utils import create_endpoint_services, durationHuman, get_endpoints_from_section
 
 
 def get_config(config_string):

--- a/src/twisted/plugins/cowrie_plugin.py
+++ b/src/twisted/plugins/cowrie_plugin.py
@@ -26,12 +26,12 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-from __future__ import print_function, division, absolute_import
+from __future__ import absolute_import, division, print_function
 
+import configparser
 import os
 import sys
 
-import configparser
 from twisted._version import __version__
 from twisted.application import service
 from twisted.application.service import IServiceMaker
@@ -40,6 +40,7 @@ from twisted.internet import reactor
 from twisted.logger import ILogObserver, globalLogPublisher
 from twisted.plugin import IPlugin
 from twisted.python import log, usage
+
 from zope.interface import implementer, provider
 
 import cowrie.core.checkers
@@ -48,7 +49,7 @@ import cowrie.ssh.factory
 import cowrie.telnet.transport
 from cowrie import core
 from cowrie.core.config import CONFIG
-from cowrie.core.utils import get_endpoints_from_section, create_endpoint_services
+from cowrie.core.utils import create_endpoint_services, get_endpoints_from_section
 
 if __version__.major < 17:
     raise ImportError("Your version of Twisted is too old. Please ensure your virtual environment is set up correctly.")


### PR DESCRIPTION
This is a better version of my previous try of improving imports.

The mistake by me was not introducing any kind of linter for this changes.
This is now covered by travis and the Docker build.

I used now `flake8-import-order` to enforce a import code style.
The tool has the advantage of declaring your own application for local imports. Other tools have been false positive in this situation because they struggled to identify local imports.

The first try was pretty close to be pep8 compatible but I chose to go the extra mile and used the default style which is more strict.

This branch is save to be blindly merged since it is just re-arranging the imports and not altering the code functionality. 