### PR TITLE
Fixing tty log path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN apk add --no-cache libffi && \
   addgroup -S cowrie && \
   adduser -S -s /bin/bash -G cowrie -D -H -h /cowrie cowrie && \
   mkdir -p /cowrie/var/lib/cowrie/downloads && \
-  mkdir -p /cowrie/var/log/cowrie/tty && \
+  mkdir -p /cowrie/var/lib/cowrie/tty && \
+  mkdir -p /cowrie/var/log/cowrie/ && \
   chown -R cowrie:cowrie /cowrie && \
   chmod -R 775 /cowrie
 COPY requirements.txt .


### PR DESCRIPTION
Log paths had still some different paths inside the Dockerfile and the
cowrie configuration. This is now fixed and the Docker image fully
functional.