### PR TITLE
Fix command yum.py

### DIFF
--- a/src/cowrie/commands/yum.py
+++ b/src/cowrie/commands/yum.py
@@ -252,21 +252,21 @@ Options:
         self.write('Running transaction\n')
         i = 1
         for p in packages:
-            self.write('  Installing : {0}-{1}-{2}.{3} \t\t\t\t {4}/{5} \n'.format(
-                (p, packages[p]['version'], packages[p]['release'], arch, i, len(packages))))
+            self.write('  Installing : {0}-{1}-{2}.{3} \t\t\t\t {4}/{5} \n'.format
+                (p, packages[p]['version'], packages[p]['release'], arch, i, len(packages)))
             yield self.sleep(0.5, 1)
             i += 1
         i = 1
         for p in packages:
-            self.write('  Verifying : {0}-{1}-{2}.{3} \t\t\t\t {4}/{5} \n'.format(
-                (p, packages[p]['version'], packages[p]['release'], arch, i, len(packages))))
+            self.write('  Verifying : {0}-{1}-{2}.{3} \t\t\t\t {4}/{5} \n'.format
+                (p, packages[p]['version'], packages[p]['release'], arch, i, len(packages)))
             yield self.sleep(0.5, 1)
             i += 1
         self.write('\n')
         self.write('Installed:\n')
         for p in packages:
-            self.write('  {0}.{1} {2}:{3}-{4} \t\t'.format(
-                (p, arch, random.randint(0, 2), packages[p]['version'], packages[p]['release'])))
+            self.write('  {0}.{1} {2}:{3}-{4} \t\t'.format
+                (p, arch, random.randint(0, 2), packages[p]['version'], packages[p]['release']))
         self.write('\n')
         self.write('Complete!\n')
         self.exit()

--- a/src/cowrie/shell/honeypot.py
+++ b/src/cowrie/shell/honeypot.py
@@ -94,7 +94,7 @@ class HoneyPotShell(object):
                 tokens.append(tok)
             except Exception as e:
                 self.protocol.terminal.write(
-                    b'bash: syntax error: unexpected end of file\n')
+                    b'-bash: syntax error: unexpected end of file\n')
                 # Could run runCommand here, but i'll just clear the list instead
                 log.msg("exception: {}".format(e))
                 self.cmdpending = []
@@ -207,7 +207,7 @@ class HoneyPotShell(object):
                     lastpp = pp
             else:
                 log.msg(eventid='cowrie.command.failed', input=' '.join(cmd2), format='Command not found: %(input)s')
-                self.protocol.terminal.write('bash: {}: command not found\n'.format(cmd['command']).encode('utf8'))
+                self.protocol.terminal.write('-bash: {}: command not found\n'.format(cmd['command']).encode('utf8'))
                 runOrPrompt()
         if pp:
             self.protocol.call_command(pp, cmdclass, *cmd_array[0]['rargs'])


### PR DESCRIPTION
Command `yum` didn't run because of obsolete parenthesis