### PR TITLE
Docker devel image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ log/
 __pycache__/
 *.py[cod]
 *env/
-twisted/plugins/dropin.cache
+src/twisted/plugins/dropin.cache
 .DS_Store
 _trial_temp
 .project


### PR DESCRIPTION
TL;DR Providing an docker image for local development.

I wanted to have a container which has all the needed tools installed
while developming (eg flake8, pytest, pydev, etc).

The intermediate container `devel` can now be used by PyCharm as a
Remote Interpreter and for debugging. No need to setup any local test
environments because we can now use a pre-release image.
Build the container with `docker build --target devel -t cowrie:devel
.` from within the project root directory.

While building the container I encountered a bug with the
`python:2-alpine3.8` image and (at least, could be other OS also beeing
affected) the macOS kernel trying to use `socket.SO_REUSEPORT`.
After some testing I found out that the problem is just this image. So I
could have just gone and downgraded to `python:2-alpine3.7` or switched over to
`alpine:latest`. But none of them really convinced me after some
research so I decided to switch the Docker image to
`debian:stable-slim`. The resulting image is now slightly bigger then
our previous image but should give a better experience while
debugging stuff. Bonus point is that we have a functional installation
description for Debian based systems.