### PR TITLE
Refactor UserDB config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && \
   chmod -R 775 /cowrie
 COPY requirements.txt .
 COPY requirements-output.txt .
-COPY data /cowrie/data
 COPY honeyfs /cowrie/honeyfs
 COPY share /cowrie/share
 COPY etc /cowrie/etc

--- a/data/userdb.txt
+++ b/data/userdb.txt
@@ -1,6 +1,0 @@
-root:x:!root
-root:x:!123456
-root:x:!/honeypot/i
-root:x:*
-richard:x:*
-richard:x:fout

--- a/etc/cowrie.cfg.dist
+++ b/etc/cowrie.cfg.dist
@@ -44,7 +44,7 @@ download_path = ${honeypot:state_path}/downloads
 # Directory for miscellaneous data files, such as the password database.
 # (DEPRECATED: will be removed in near future)
 # (default: data)
-data_path = data
+data_path = etc
 
 
 # Directory for static data files


### PR DESCRIPTION
The data_path has changed to etc/. I'm not really happy with this but
I didn't had a better idea since we allow configs to be in ., etc/ and
/etc. Maybe we wanna changes this behaviour when we have a stable docker
release.

If the userdb.txt is not found Cowrie will load a default list.
The parser is now also a bit less error prone when parsing this file.