### PR TITLE
fix: release integrity, ssh_proxy parity and DNS-rebinding in outbound downloads

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,13 +20,6 @@ on:  # yamllint disable-line rule:truthy
 
   # Run manually
   workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
-      tags:
-        description: 'Build and publish Docker image'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build setuptools==80.9.0 setuptools-scm==9.2.0 twine==6.2.0 wheel==0.45.1 packaging==25.0
+          python -m pip install build setuptools==83.0.0 setuptools-scm==9.2.0 twine==6.2.0 wheel==0.45.1 packaging==26.2
 
       - name: Build and check
         run: |

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -69,7 +69,11 @@ jobs:
         if: ${{ github.repository == 'cowrie/cowrie' }}
         run: |
           set -eu
-          python -m pip install cowrie
+          # Install exactly the version this run built; a plain
+          # 'pip install cowrie' can silently test the previous release
+          # when the index has not propagated yet.
+          EXPECTED=$(python -c "from setuptools_scm import get_version; print(get_version(local_scheme='no-local-version'))")
+          python -m pip install "cowrie==${EXPECTED}"
 
           # entry point is registered and on PATH
           which cowrie
@@ -91,4 +95,4 @@ jobs:
 
           # cowrie start refuses to run from uninitialised dirs
           rm -rf /tmp/cowrie-empty && mkdir /tmp/cowrie-empty && cd /tmp/cowrie-empty
-          cowrie start 2>&1 | grep -q "not initialised"
+          cowrie start 2>&1 | grep -q "not initialized"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -12,13 +12,6 @@ on:  # yamllint disable-line rule:truthy
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
   workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
-      tags:
-        description: 'pypi upload'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -39,8 +39,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install build setuptools==83.0.0 setuptools-scm==9.2.0 twine==6.2.0 wheel==0.45.1 packaging==26.2
+          python -m pip install build==1.5.0 setuptools==83.0.0 setuptools-scm==9.2.0 twine==6.2.0 wheel==0.45.1 packaging==26.2
 
       - name: Build and check
         run: |

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build setuptools==80.9.0 setuptools-scm==9.2.0 twine==6.2.0 wheel==0.45.1 packaging==25.0
+          python -m pip install build setuptools==83.0.0 setuptools-scm==9.2.0 twine==6.2.0 wheel==0.45.1 packaging==26.2
 
       - name: Build and check
         run: |

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -12,13 +12,6 @@ on:  # yamllint disable-line rule:truthy
       - main
 
   workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
-      tags:
-        description: 'test-pypi upload'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -70,7 +70,11 @@ jobs:
         if: ${{ github.repository == 'cowrie/cowrie' }}
         run: |
           set -eu
-          python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ cowrie
+          # Install exactly the version this run built; a plain
+          # 'pip install cowrie' can silently test the previous release
+          # when the index has not propagated yet.
+          EXPECTED=$(python -c "from setuptools_scm import get_version; print(get_version(local_scheme='no-local-version'))")
+          python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "cowrie==${EXPECTED}"
 
           # entry point is registered and on PATH
           which cowrie
@@ -92,4 +96,4 @@ jobs:
 
           # cowrie start refuses to run from uninitialised dirs
           rm -rf /tmp/cowrie-empty && mkdir /tmp/cowrie-empty && cd /tmp/cowrie-empty
-          cowrie start 2>&1 | grep -q "not initialised"
+          cowrie start 2>&1 | grep -q "not initialized"

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -39,8 +39,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install build setuptools==83.0.0 setuptools-scm==9.2.0 twine==6.2.0 wheel==0.45.1 packaging==26.2
+          python -m pip install build==1.5.0 setuptools==83.0.0 setuptools-scm==9.2.0 twine==6.2.0 wheel==0.45.1 packaging==26.2
 
       - name: Build and check
         run: |

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -27,9 +27,13 @@ concurrency:
 
 jobs:
   test:
+    # Guard forks: without this the schedule also fires on clones and mints
+    # its own tag series there, which poisons setuptools-scm versioning.
+    if: github.repository == 'cowrie/cowrie'
     uses: ./.github/workflows/tox.yml
 
   weekly-release:
+    if: github.repository == 'cowrie/cowrie'
     needs: test
     runs-on: ubuntu-latest
     permissions:

--- a/src/cowrie/commands/curl.py
+++ b/src/cowrie/commands/curl.py
@@ -15,28 +15,26 @@ from twisted.internet import error, reactor
 from twisted.internet.defer import inlineCallbacks
 from twisted.logger import Logger
 from twisted.python import failure
-from twisted.web.client import Agent
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
+from cowrie.core.download import (
+    BlockedAddress,
+    capture_download,
+    fetch,
+    outbound_rate_limiter,
+    report_download_failure,
+)
 from cowrie.core.network import (
     DownloadLimitExceeded,
     abort_body,
     communication_allowed,
-    outbound_bind_address,
 )
-from cowrie.core.rate_limiter import RateLimiter
 from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
 
-# Initialize rate limiter
-curl_rate_limiter = RateLimiter(
-    enabled=CowrieConfig.getboolean("shell", "curl_rate_limit_enabled", fallback=True),
-    max_requests=CowrieConfig.getint("shell", "curl_rate_limit_requests", fallback=5),
-    window_seconds=CowrieConfig.getint("shell", "curl_rate_limit_window", fallback=60),
-    max_keys=CowrieConfig.getint("shell", "curl_rate_limit_max_hosts", fallback=1000),
-)
+curl_rate_limiter = outbound_rate_limiter("curl")
 
 CURL_HELP = """Usage: curl [options...] <url>
 Options: (H) means HTTP/HTTPS only, (F) means FTP only
@@ -337,18 +335,16 @@ class Command_curl(HoneyPotCommand):
         """
         headers = {"User-Agent": ["curl/7.38.0"]}
 
-        # Bind the outbound connection to the configured source address so the
-        # download does not leak the honeypot's real interface IP.
-        agent = Agent(reactor, bindAddress=(outbound_bind_address(), 0))
-        if self.head_request:
-            deferred = treq.head(
-                url=url, agent=agent, allow_redirects=False, headers=headers, timeout=10
-            )
-        else:
-            deferred = treq.get(
-                url=url, agent=agent, allow_redirects=False, headers=headers, timeout=10
-            )
-        return deferred
+        # curl reports a redirect rather than following it unless -L is given,
+        # which cowrie does not implement, so stop at the first response.
+        return fetch(
+            reactor,
+            url,
+            method="head" if self.head_request else "get",
+            headers=headers,
+            timeout=10,
+            max_redirects=0,
+        )
 
     def handle_CTRL_C(self) -> None:
         self.write("^C\n")
@@ -463,26 +459,12 @@ class Command_curl(HoneyPotCommand):
         if self.outfile and not self.silent:
             self.write("\n")
 
-        # Update the honeyfs to point to artifact file if output is to file
-        if self.outfile and self.protocol.user:
-            self.fs.mkfile(
-                self.outfile,
-                self.user["uid"],
-                self.user["gid"],
-                self.currentlength,
-                33188,
-            )
-            self.fs.update_realfile(
-                self.fs.getfile(self.outfile), self.artifact.shasumFilename
-            )
-
-        self.protocol.events.dispatch(
-            "cowrie.session.file_download",
-            "Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
-            url=self.url.decode(),
-            outfile=self.artifact.shasumFilename,
-            shasum=self.artifact.shasum,
-            duplicate=self.artifact.duplicate,
+        capture_download(
+            self,
+            self.artifact,
+            self.url.decode(),
+            outfile=self.outfile,
+            size=self.currentlength,
         )
         self.exit()
 
@@ -495,16 +477,14 @@ class Command_curl(HoneyPotCommand):
             # late failure of that transfer is not this command's outcome.
             return
         self.exit_code = 1
-        # Close the artifact so a failed download leaves no orphaned temp file.
-        # Artifact.close() removes the empty temp file backing the download.
-        if getattr(self, "artifact", None) is not None:
-            self.artifact.close()
+        report_download_failure(self, self.url.decode())
 
-        self.protocol.events.dispatch(
-            "cowrie.session.file_download.failed",
-            "Attempt to download file(s) from URL (%(url)s) failed",
-            url=self.url.decode(),
-        )
+        if response.check(BlockedAddress) is not None:
+            self.errorWrite(
+                f"curl: (6) Could not resolve host: {response.value.host}\n"
+            )
+            self.exit()
+            return
 
         if response.check(error.DNSLookupError) is not None:
             self.errorWrite(f"curl: (6) Could not resolve host: {self.host}\n")

--- a/src/cowrie/commands/ftpget.py
+++ b/src/cowrie/commands/ftpget.py
@@ -19,8 +19,8 @@ from twisted.protocols.ftp import CommandFailed, FTPClient
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
-from cowrie.core.network import communication_allowed, outbound_bind_address
-from cowrie.core.rate_limiter import RateLimiter
+from cowrie.core.download import outbound_rate_limiter
+from cowrie.core.network import outbound_bind_address, resolve_allowed
 from cowrie.shell.command import HoneyPotCommand
 
 if TYPE_CHECKING:
@@ -29,16 +29,7 @@ if TYPE_CHECKING:
 commands = {}
 
 # Per-host limiter on outbound FTP connections, matching wget/curl.
-ftpget_rate_limiter = RateLimiter(
-    enabled=CowrieConfig.getboolean(
-        "shell", "ftpget_rate_limit_enabled", fallback=True
-    ),
-    max_requests=CowrieConfig.getint("shell", "ftpget_rate_limit_requests", fallback=5),
-    window_seconds=CowrieConfig.getint(
-        "shell", "ftpget_rate_limit_window", fallback=60
-    ),
-    max_keys=CowrieConfig.getint("shell", "ftpget_rate_limit_max_hosts", fallback=1000),
-)
+ftpget_rate_limiter = outbound_rate_limiter("ftpget")
 
 
 class FTPFileReceiver(Protocol):
@@ -172,8 +163,11 @@ Download a file via FTP
             self.exit(1)
             return
 
-        allowed = yield communication_allowed(self.host)
-        if not allowed:
+        # Connect to this exact address rather than the hostname: resolving
+        # again at connect time lets a malicious DNS server answer the check
+        # and the connection differently.
+        self.resolved_host = yield resolve_allowed(self.host)
+        if self.resolved_host is None:
             self.exit(1)
             return
 
@@ -216,7 +210,7 @@ Download a file via FTP
             self.write(f"Connecting to {self.host}\n")
 
         d = creator.connectTCP(
-            self.host,
+            self.resolved_host,
             self.port,
             timeout=30,
             bindAddress=(outbound_bind_address(), 0),
@@ -298,6 +292,20 @@ Download a file via FTP
             limit=self.limit_size,
         )
         self.errorWrite("ftpget: file exceeds download size limit\n")
+
+    def handle_CTRL_C(self) -> None:
+        self.write("^C\n")
+        self.exit()
+
+    def exit(self, code: int | None = None) -> None:
+        # Close the download artifact on every exit path so an aborted
+        # transfer does not leave its empty temp file behind in the download
+        # directory. close() is idempotent and removes an empty artifact, so
+        # the normal success/error paths are unaffected.
+        artifact = getattr(self, "artifactFile", None)
+        if artifact is not None:
+            artifact.close()
+        HoneyPotCommand.exit(self, code)
 
     def _download_success(self, result: None) -> None:
         """

--- a/src/cowrie/commands/nc.py
+++ b/src/cowrie/commands/nc.py
@@ -16,12 +16,12 @@ from twisted.internet.protocol import ClientFactory, Protocol, connectionDone
 from twisted.logger import Logger
 
 from cowrie.core.config import CowrieConfig
+from cowrie.core.download import outbound_rate_limiter
 from cowrie.core.network import (
     is_valid_port,
     outbound_bind_address,
     resolve_allowed,
 )
-from cowrie.core.rate_limiter import RateLimiter
 from cowrie.shell.command import HoneyPotCommand
 
 if TYPE_CHECKING:
@@ -32,13 +32,7 @@ long = int
 
 commands = {}
 
-# Initialize rate limiter
-nc_rate_limiter = RateLimiter(
-    enabled=CowrieConfig.getboolean("shell", "nc_rate_limit_enabled", fallback=True),
-    max_requests=CowrieConfig.getint("shell", "nc_rate_limit_requests", fallback=5),
-    window_seconds=CowrieConfig.getint("shell", "nc_rate_limit_window", fallback=60),
-    max_keys=CowrieConfig.getint("shell", "nc_rate_limit_max_hosts", fallback=1000),
-)
+nc_rate_limiter = outbound_rate_limiter("nc")
 
 
 def makeMask(n: int) -> int:

--- a/src/cowrie/commands/tftp.py
+++ b/src/cowrie/commands/tftp.py
@@ -15,6 +15,7 @@ from twisted.logger import Logger
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
+from cowrie.core.download import outbound_rate_limiter
 from cowrie.core.network import (
     DownloadLimitExceeded,
     communication_allowed,
@@ -22,7 +23,6 @@ from cowrie.core.network import (
     is_valid_port,
     outbound_bind_address,
 )
-from cowrie.core.rate_limiter import RateLimiter
 from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.customparser import CustomParser, ExitException, OptionNotFound
 
@@ -34,12 +34,7 @@ commands = {}
 
 # Bound how many outbound TFTP transfers per destination a session can trigger,
 # so the honeypot cannot be used to flood a victim host.
-tftp_rate_limiter = RateLimiter(
-    enabled=CowrieConfig.getboolean("shell", "tftp_rate_limit_enabled", fallback=True),
-    max_requests=CowrieConfig.getint("shell", "tftp_rate_limit_requests", fallback=5),
-    window_seconds=CowrieConfig.getint("shell", "tftp_rate_limit_window", fallback=60),
-    max_keys=CowrieConfig.getint("shell", "tftp_rate_limit_max_hosts", fallback=1000),
-)
+tftp_rate_limiter = outbound_rate_limiter("tftp")
 
 # TFTP Opcodes (RFC 1350)
 OPCODE_RRQ = 1  # Read request

--- a/src/cowrie/commands/wget.py
+++ b/src/cowrie/commands/wget.py
@@ -18,29 +18,28 @@ from twisted.internet.protocol import ClientCreator, Protocol
 from twisted.logger import Logger
 from twisted.protocols.ftp import CommandFailed, FTPClient
 from twisted.python import failure
-from twisted.web.client import Agent
 from twisted.web.iweb import UNKNOWN_LENGTH
 
 from cowrie.core.artifact import Artifact
 from cowrie.core.config import CowrieConfig
+from cowrie.core.download import (
+    BlockedAddress,
+    capture_download,
+    fetch,
+    outbound_rate_limiter,
+    report_download_failure,
+)
 from cowrie.core.network import (
     DownloadLimitExceeded,
     abort_body,
     communication_allowed,
     outbound_bind_address,
 )
-from cowrie.core.rate_limiter import RateLimiter
 from cowrie.shell.command import HoneyPotCommand
 
 commands = {}
 
-# Initialize rate limiter
-wget_rate_limiter = RateLimiter(
-    enabled=CowrieConfig.getboolean("shell", "wget_rate_limit_enabled", fallback=True),
-    max_requests=CowrieConfig.getint("shell", "wget_rate_limit_requests", fallback=5),
-    window_seconds=CowrieConfig.getint("shell", "wget_rate_limit_window", fallback=60),
-    max_keys=CowrieConfig.getint("shell", "wget_rate_limit_max_hosts", fallback=1000),
-)
+wget_rate_limiter = outbound_rate_limiter("wget")
 
 
 def tdiff(seconds: int) -> str:
@@ -325,13 +324,7 @@ class Command_wget(HoneyPotCommand):
             "User-Agent": [f"Wget/{self.wget_version} (linux-gnu)"]
         }
 
-        # Bind the outbound connection to the configured source address so the
-        # download does not leak the honeypot's real interface IP.
-        agent = Agent(reactor, bindAddress=(outbound_bind_address(), 0))
-        deferred = treq.get(
-            url=url, agent=agent, allow_redirects=True, headers=headers, timeout=10
-        )
-        return deferred
+        return fetch(reactor, url, headers=headers, timeout=10)
 
     def ftpDownload(self, urldata: parse.ParseResult) -> Any:
         """
@@ -630,26 +623,12 @@ class Command_wget(HoneyPotCommand):
                 )
             )
 
-        # Update the honeyfs to point to artifact file if output is to file
-        if self.outfile and self.outfile != "-" and self.protocol.user:
-            self.fs.mkfile(
-                self.outfile,
-                self.user["uid"],
-                self.user["gid"],
-                self.currentlength,
-                33188,
-            )
-            self.fs.update_realfile(
-                self.fs.getfile(self.outfile), self.artifact.shasumFilename
-            )
-
-        self.protocol.events.dispatch(
-            "cowrie.session.file_download",
-            "Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
-            url=self.url.decode(),
-            outfile=self.artifact.shasumFilename,
-            shasum=self.artifact.shasum,
-            duplicate=self.artifact.duplicate,
+        capture_download(
+            self,
+            self.artifact,
+            self.url.decode(),
+            outfile=None if self.outfile == "-" else self.outfile,
+            size=self.currentlength,
         )
         self.exit()
 
@@ -662,16 +641,15 @@ class Command_wget(HoneyPotCommand):
             # late failure of that transfer is not this command's outcome.
             return
         self.exit_code = 1
-        # Close the artifact so a failed download leaves no orphaned temp file.
-        # Artifact.close() removes the empty temp file backing the download.
-        if getattr(self, "artifact", None) is not None:
-            self.artifact.close()
+        report_download_failure(self, self.url.decode())
 
-        self.protocol.events.dispatch(
-            "cowrie.session.file_download.failed",
-            "Attempt to download file(s) from URL (%(url)s) failed",
-            url=self.url.decode(),
-        )
+        if response.check(BlockedAddress) is not None:
+            # A redirect reached a host the honeypot must not contact.
+            self.errorWrite(
+                f"wget: unable to resolve host address ‘{response.value.host}’\n"
+            )
+            self.exit()
+            return
 
         if response.check(error.DNSLookupError) is not None:
             self.errorWrite(

--- a/src/cowrie/core/download.py
+++ b/src/cowrie/core/download.py
@@ -7,7 +7,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urljoin, urlparse
 
 import treq
@@ -99,9 +99,10 @@ def pinned_agent(reactor: IReactorCore, address: str, policy: Any = None) -> Age
     validation lookup with a public address and the connection lookup with a
     private one.
     """
-    return Agent.usingEndpointFactory(
+    agent = Agent.usingEndpointFactory(
         reactor, _PinnedEndpointFactory(reactor, address, policy)
     )
+    return cast("Agent", agent)
 
 
 @inlineCallbacks

--- a/src/cowrie/core/download.py
+++ b/src/cowrie/core/download.py
@@ -8,19 +8,39 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urljoin, urlparse
 
+import treq
+from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.internet.endpoints import HostnameEndpoint, wrapClientTLS
 from twisted.web.client import Agent, BrowserLikePolicyForHTTPS
 
 from cowrie.core.config import CowrieConfig
-from cowrie.core.network import outbound_bind_address
+from cowrie.core.network import outbound_bind_address, resolve_allowed
 from cowrie.core.rate_limiter import RateLimiter
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from twisted.internet.interfaces import IReactorCore
     from twisted.web.client import URI
 
     from cowrie.core.artifact import Artifact
+
+# Redirect codes that send the client to a new location.
+_REDIRECT_CODES = (301, 302, 303, 307, 308)
+
+
+class BlockedAddress(Exception):
+    """The requested host resolves to an address the honeypot must not reach."""
+
+    def __init__(self, host: str) -> None:
+        super().__init__(f"blocked address for host {host}")
+        self.host = host
+
+
+class TooManyRedirects(Exception):
+    """A redirect chain ran past its hop limit."""
 
 
 def outbound_rate_limiter(command: str) -> RateLimiter:
@@ -82,6 +102,44 @@ def pinned_agent(reactor: IReactorCore, address: str, policy: Any = None) -> Age
     return Agent.usingEndpointFactory(
         reactor, _PinnedEndpointFactory(reactor, address, policy)
     )
+
+
+@inlineCallbacks
+def fetch(
+    reactor: IReactorCore,
+    url: str,
+    method: str = "get",
+    headers: dict[Any, Any] | None = None,
+    timeout: int = 10,
+    max_redirects: int = 5,
+) -> Generator[Deferred, Any, Any]:
+    """Fetch ``url``, validating every hop and connecting to what was validated.
+
+    Redirects are followed here rather than by the agent so each new location
+    is checked against the blocklist; an agent following them itself would
+    reach whatever the redirect names.
+    """
+    for _ in range(max_redirects + 1):
+        host = urlparse(url).hostname or ""
+        address = yield resolve_allowed(host)
+        if address is None:
+            raise BlockedAddress(host)
+
+        response = yield getattr(treq, method)(
+            url=url,
+            agent=pinned_agent(reactor, address),
+            allow_redirects=False,
+            headers=headers,
+            timeout=timeout,
+        )
+
+        location = response.headers.getRawHeaders("location")
+        if response.code not in _REDIRECT_CODES or not location:
+            return response
+
+        url = urljoin(url, location[0])
+
+    raise TooManyRedirects
 
 
 def capture_download(

--- a/src/cowrie/core/download.py
+++ b/src/cowrie/core/download.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Shared machinery for the commands that fetch files from the network.
+# ABOUTME: Rate limiting, address-pinned HTTP connections and artifact capture.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from twisted.internet.endpoints import HostnameEndpoint, wrapClientTLS
+from twisted.web.client import Agent, BrowserLikePolicyForHTTPS
+
+from cowrie.core.config import CowrieConfig
+from cowrie.core.network import outbound_bind_address
+from cowrie.core.rate_limiter import RateLimiter
+
+if TYPE_CHECKING:
+    from twisted.internet.interfaces import IReactorCore
+    from twisted.web.client import URI
+
+    from cowrie.core.artifact import Artifact
+
+
+def outbound_rate_limiter(command: str) -> RateLimiter:
+    """Build the outbound rate limiter for one fetching command.
+
+    Each command reads its own ``[shell] <command>_rate_limit_*`` settings so
+    an operator can loosen one without loosening the rest.
+    """
+    return RateLimiter(
+        enabled=CowrieConfig.getboolean(
+            "shell", f"{command}_rate_limit_enabled", fallback=True
+        ),
+        max_requests=CowrieConfig.getint(
+            "shell", f"{command}_rate_limit_requests", fallback=5
+        ),
+        window_seconds=CowrieConfig.getint(
+            "shell", f"{command}_rate_limit_window", fallback=60
+        ),
+        max_keys=CowrieConfig.getint(
+            "shell", f"{command}_rate_limit_max_hosts", fallback=1000
+        ),
+    )
+
+
+class _PinnedEndpointFactory:
+    """Builds connections to one pre-validated address.
+
+    The URI's hostname still drives TLS verification and SNI; only the
+    address we connect to is fixed.
+    """
+
+    def __init__(self, reactor: IReactorCore, address: str, policy: Any = None) -> None:
+        self._reactor = reactor
+        self._address = address
+        self._policy = policy if policy is not None else BrowserLikePolicyForHTTPS()
+
+    def endpointForURI(self, uri: URI) -> Any:
+        endpoint = HostnameEndpoint(
+            self._reactor,
+            self._address,
+            uri.port,
+            bindAddress=(outbound_bind_address(), 0),
+        )
+        if uri.scheme == b"https":
+            return wrapClientTLS(
+                self._policy.creatorForNetloc(uri.host, uri.port), endpoint
+            )
+        return endpoint
+
+
+def pinned_agent(reactor: IReactorCore, address: str, policy: Any = None) -> Agent:
+    """An HTTP agent that connects to ``address`` instead of resolving again.
+
+    The blocklist check resolves the hostname once; connecting by name would
+    resolve it a second time, letting a malicious DNS server answer the
+    validation lookup with a public address and the connection lookup with a
+    private one.
+    """
+    return Agent.usingEndpointFactory(
+        reactor, _PinnedEndpointFactory(reactor, address, policy)
+    )
+
+
+def capture_download(
+    command: Any,
+    artifact: Artifact,
+    url: str,
+    outfile: str | None = None,
+    size: int = 0,
+) -> None:
+    """Record a completed download: honeyfs entry plus the session event.
+
+    ``outfile`` is the path inside the honeyfs the attacker asked for, or
+    None when the payload was written to stdout and never landed in the
+    fake filesystem.
+    """
+    if outfile and command.protocol.user:
+        command.fs.mkfile(
+            outfile,
+            command.user["uid"],
+            command.user["gid"],
+            size,
+            33188,
+        )
+        command.fs.update_realfile(command.fs.getfile(outfile), artifact.shasumFilename)
+
+    command.protocol.events.dispatch(
+        "cowrie.session.file_download",
+        "Downloaded URL (%(url)s) with SHA-256 %(shasum)s to %(outfile)s",
+        url=url,
+        outfile=artifact.shasumFilename,
+        shasum=artifact.shasum,
+        duplicate=artifact.duplicate,
+    )
+
+
+def report_download_failure(command: Any, url: str) -> None:
+    """Record a download that never completed, discarding its temp file."""
+    artifact = getattr(command, "artifact", None)
+    if artifact is not None:
+        artifact.close()
+
+    command.protocol.events.dispatch(
+        "cowrie.session.file_download.failed",
+        "Attempt to download file(s) from URL (%(url)s) failed",
+        url=url,
+    )

--- a/src/cowrie/core/download.py
+++ b/src/cowrie/core/download.py
@@ -117,9 +117,11 @@ def fetch(
 
     Redirects are followed here rather than by the agent so each new location
     is checked against the blocklist; an agent following them itself would
-    reach whatever the redirect names.
+    reach whatever the redirect names. With ``max_redirects`` at 0 the
+    redirect response is returned as-is, for callers that report redirects
+    instead of following them.
     """
-    for _ in range(max_redirects + 1):
+    for hop in range(max_redirects + 1):
         host = urlparse(url).hostname or ""
         address = yield resolve_allowed(host)
         if address is None:
@@ -134,12 +136,12 @@ def fetch(
         )
 
         location = response.headers.getRawHeaders("location")
-        if response.code not in _REDIRECT_CODES or not location:
+        if not max_redirects or response.code not in _REDIRECT_CODES or not location:
             return response
+        if hop == max_redirects:
+            raise TooManyRedirects
 
         url = urljoin(url, location[0])
-
-    raise TooManyRedirects
 
 
 def capture_download(

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -421,7 +421,8 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
             # With python >= 3 we can use super?
             transport.SSHServerTransport.sendDisconnect(self, reason, desc)
         else:
-            self.transport.write(b"Packet corrupt\n")
+            # this message is used to detect Cowrie behaviour
+            # self.transport.write(b"Packet corrupt\n")
             self._log.info(
                 "Disconnecting with error, code {code}\nreason: {desc}",
                 code=reason,

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -281,6 +281,8 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
         """
         Override because OpenSSH pads with 0 on KEXINIT
         """
+        if self.transport is None:
+            return
         if self._keyExchangeState != self._KEY_EXCHANGE_NONE:
             if not self._allowedKeyExchangeMessageType(messageType):
                 self._blockedByKeyExchange.append((messageType, payload))

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -288,7 +288,7 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
                 self._blockedByKeyExchange.append((messageType, payload))
                 return
 
-        payload = chr(messageType).encode() + payload
+        payload = bytes((messageType,)) + payload
         if self.outgoingCompression:
             payload = self.outgoingCompression.compress(
                 payload

--- a/src/cowrie/ssh_proxy/server_transport.py
+++ b/src/cowrie/ssh_proxy/server_transport.py
@@ -234,7 +234,7 @@ class FrontendSSHTransport(transport.SSHServerTransport, TimeoutMixin):
                     "Remote SSH version: %(version)s",
                     version=escape_nonprintable(self.otherVersionString),
                 )
-            m = re.match(rb"SSH-(\d+.\d+)-(.*)", self.otherVersionString)
+            m = re.match(rb"SSH-(\d+\.\d+)-(.*)", self.otherVersionString)
             if m is None:
                 self._log.info(
                     "Bad protocol version identification: {version!r}",

--- a/src/cowrie/test/test_curl.py
+++ b/src/cowrie/test/test_curl.py
@@ -15,6 +15,7 @@ from unittest import mock
 
 from twisted.internet import defer, error
 from twisted.python.failure import Failure
+from twisted.web.client import URI
 from twisted.web.http_headers import Headers
 
 from cowrie.commands.curl import Command_curl
@@ -180,7 +181,8 @@ class CurlOutboundBindTests(unittest.TestCase):
     def tearDown(self) -> None:
         CowrieConfig.remove_option("honeypot", "out_addr")
 
-    def _capture_agent(self, head_request: bool, verb: str) -> Any:
+    def _capture_bind_address(self, head_request: bool, verb: str) -> Any:
+        """Return the source address the connection curl builds would bind to."""
         cmd = Command_curl.__new__(Command_curl)
         cmd.head_request = head_request
 
@@ -188,26 +190,40 @@ class CurlOutboundBindTests(unittest.TestCase):
 
         def fake_verb(url: str, agent: Any = None, **kwargs: Any) -> Any:
             captured["agent"] = agent
-            return defer.succeed(None)
+            return defer.succeed(mock.Mock(code=200, headers=Headers()))
 
-        with mock.patch(f"cowrie.commands.curl.treq.{verb}", fake_verb):
+        with (
+            mock.patch(f"cowrie.core.download.treq.{verb}", fake_verb),
+            mock.patch(
+                "cowrie.core.download.resolve_allowed",
+                lambda _host: defer.succeed("198.51.100.1"),
+            ),
+        ):
             cmd.treqDownload("http://198.51.100.1/x")
 
-        return captured["agent"]
+        endpoint = captured["agent"]._endpointFactory.endpointForURI(
+            URI.fromBytes(b"http://198.51.100.1/x")
+        )
+        return endpoint._bindAddress
 
     def test_get_binds_agent_to_out_addr(self) -> None:
         CowrieConfig.set("honeypot", "out_addr", "127.0.0.1")
-        agent = self._capture_agent(head_request=False, verb="get")
-        self.assertEqual(agent._endpointFactory._bindAddress, ("127.0.0.1", 0))
+        self.assertEqual(
+            self._capture_bind_address(head_request=False, verb="get"),
+            ("127.0.0.1", 0),
+        )
 
     def test_head_binds_agent_to_out_addr(self) -> None:
         CowrieConfig.set("honeypot", "out_addr", "127.0.0.1")
-        agent = self._capture_agent(head_request=True, verb="head")
-        self.assertEqual(agent._endpointFactory._bindAddress, ("127.0.0.1", 0))
+        self.assertEqual(
+            self._capture_bind_address(head_request=True, verb="head"),
+            ("127.0.0.1", 0),
+        )
 
     def test_default_bind_is_wildcard(self) -> None:
-        agent = self._capture_agent(head_request=False, verb="get")
-        self.assertEqual(agent._endpointFactory._bindAddress, ("0.0.0.0", 0))
+        self.assertEqual(
+            self._capture_bind_address(head_request=False, verb="get"), ("0.0.0.0", 0)
+        )
 
 
 class CurlStdoutOutputTests(unittest.TestCase):

--- a/src/cowrie/test/test_download.py
+++ b/src/cowrie/test/test_download.py
@@ -119,10 +119,11 @@ class TestFetch(unittest.TestCase):
             self.requested.append((url, agent._endpointFactory._address))
             return defer.succeed(self.responses.pop(0))
 
-        for target, attr in ((download, "resolve_allowed"), (download.treq, "get")):
-            patcher = mock.patch.object(
-                target, attr, fake_resolve if attr == "resolve_allowed" else fake_get
-            )
+        for target, replacement in (
+            ("cowrie.core.download.resolve_allowed", fake_resolve),
+            ("cowrie.core.download.treq.get", fake_get),
+        ):
+            patcher = mock.patch(target, replacement)
             patcher.start()
             self.addCleanup(patcher.stop)
 

--- a/src/cowrie/test/test_download.py
+++ b/src/cowrie/test/test_download.py
@@ -174,6 +174,21 @@ class TestFetch(unittest.TestCase):
             ["http://example.invalid/first", "http://example.invalid/second"],
         )
 
+    def test_redirect_is_returned_when_not_following(self) -> None:
+        # curl reports a redirect rather than following it, so the response
+        # must come back instead of being treated as an over-long chain.
+        self.responses = [FakeResponse(302, "http://elsewhere.invalid/x")]
+
+        collected: list[Any] = []
+        failure: list[Any] = []
+        download.fetch(
+            reactor, "http://example.invalid/x", max_redirects=0
+        ).addCallbacks(collected.append, failure.append)
+
+        self.assertFalse(failure)
+        self.assertEqual(collected[0].code, 302)
+        self.assertEqual(self.validated, ["example.invalid"])
+
     def test_redirect_loop_gives_up(self) -> None:
         self.responses = [FakeResponse(302, "http://example.invalid/x")] * 10
 

--- a/src/cowrie/test/test_download.py
+++ b/src/cowrie/test/test_download.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for the shared machinery behind the file-fetching commands.
+# ABOUTME: Covers rate-limiter construction and connecting to a pinned address.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+from twisted.internet import reactor
+from twisted.web.client import URI
+
+from cowrie.core import download
+from cowrie.core.config import CowrieConfig
+
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
+
+
+class TestOutboundRateLimiter(unittest.TestCase):
+    """Every fetching command reads the same four settings under its own name."""
+
+    def test_reads_the_commands_own_settings(self) -> None:
+        CowrieConfig.read_string(
+            "[shell]\n"
+            "wget_rate_limit_requests = 7\n"
+            "wget_rate_limit_window = 30\n"
+            "wget_rate_limit_max_hosts = 12\n"
+        )
+        self.addCleanup(CowrieConfig.remove_section, "shell")
+
+        limiter = download.outbound_rate_limiter("wget")
+
+        self.assertTrue(limiter.enabled)
+        self.assertEqual(limiter.max_requests, 7)
+        self.assertEqual(limiter.window_seconds, 30)
+        self.assertEqual(limiter.max_keys, 12)
+
+    def test_defaults_when_unconfigured(self) -> None:
+        limiter = download.outbound_rate_limiter("tftp")
+
+        self.assertTrue(limiter.enabled)
+        self.assertEqual(limiter.max_requests, 5)
+        self.assertEqual(limiter.window_seconds, 60)
+        self.assertEqual(limiter.max_keys, 1000)
+
+
+class TestPinnedAgent(unittest.TestCase):
+    """HTTP requests must go to the validated address, not re-resolve the name."""
+
+    def test_connects_to_the_pinned_address(self) -> None:
+        # Re-resolving at connect time lets a malicious server answer the
+        # validation lookup with a public IP and the connection lookup with
+        # a private one.
+        agent = download.pinned_agent(reactor, "203.0.113.9")
+
+        endpoint = agent._endpointFactory.endpointForURI(
+            URI.fromBytes(b"http://example.invalid/payload")
+        )
+
+        self.assertEqual(endpoint._hostText, "203.0.113.9")
+        self.assertEqual(endpoint._port, 80)
+
+    def test_https_still_negotiates_tls_for_the_hostname(self) -> None:
+        # The pinned address is only where we connect; TLS verification and
+        # SNI still belong to the name the attacker asked for, so the
+        # endpoint must stay wrapped rather than becoming a bare connection.
+        agent = download.pinned_agent(reactor, "203.0.113.9")
+
+        endpoint = agent._endpointFactory.endpointForURI(
+            URI.fromBytes(b"https://example.invalid/payload")
+        )
+
+        inner = endpoint._wrappedEndpoint
+        self.assertEqual(inner._hostText, "203.0.113.9")
+        self.assertEqual(inner._port, 443)
+
+    def test_tls_is_negotiated_for_the_requested_hostname(self) -> None:
+        # Certificate validation and SNI must use the hostname; pinning the
+        # address must not downgrade them to the bare IP.
+        policy = MagicMock()
+        agent = download.pinned_agent(reactor, "203.0.113.9", policy=policy)
+
+        agent._endpointFactory.endpointForURI(
+            URI.fromBytes(b"https://example.invalid/payload")
+        )
+
+        policy.creatorForNetloc.assert_called_once_with(b"example.invalid", 443)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_download.py
+++ b/src/cowrie/test/test_download.py
@@ -10,10 +10,13 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
+from typing import Any
+from unittest import mock
 from unittest.mock import MagicMock
 
-from twisted.internet import reactor
+from twisted.internet import defer, reactor
 from twisted.web.client import URI
+from twisted.web.http_headers import Headers
 
 from cowrie.core import download
 from cowrie.core.config import CowrieConfig
@@ -90,6 +93,94 @@ class TestPinnedAgent(unittest.TestCase):
         )
 
         policy.creatorForNetloc.assert_called_once_with(b"example.invalid", 443)
+
+
+class FakeResponse:
+    def __init__(self, code: int = 200, location: str | None = None) -> None:
+        self.code = code
+        self.headers = Headers()
+        if location is not None:
+            self.headers.setRawHeaders("location", [location])
+
+
+class TestFetch(unittest.TestCase):
+    """Every hop of a fetch is validated and connected to by address."""
+
+    def setUp(self) -> None:
+        self.validated: list[str] = []
+        self.requested: list[tuple[str, str]] = []
+        self.responses: list[FakeResponse] = []
+
+        def fake_resolve(host: str) -> Any:
+            self.validated.append(host)
+            return defer.succeed(None if host.startswith("blocked") else "203.0.113.9")
+
+        def fake_get(url: str, agent: Any = None, **kwargs: Any) -> Any:
+            self.requested.append((url, agent._endpointFactory._address))
+            return defer.succeed(self.responses.pop(0))
+
+        for target, attr in ((download, "resolve_allowed"), (download.treq, "get")):
+            patcher = mock.patch.object(
+                target, attr, fake_resolve if attr == "resolve_allowed" else fake_get
+            )
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def _fetch(self, url: str) -> Any:
+        result: list[Any] = []
+        failure: list[Any] = []
+        download.fetch(reactor, url).addCallbacks(result.append, failure.append)
+        return result, failure
+
+    def test_returns_the_response_for_a_direct_hit(self) -> None:
+        self.responses = [FakeResponse()]
+
+        _result, failure = self._fetch("http://example.invalid/payload")
+
+        self.assertFalse(failure)
+        self.assertEqual(self.validated, ["example.invalid"])
+        self.assertEqual(
+            self.requested, [("http://example.invalid/payload", "203.0.113.9")]
+        )
+
+    def test_blocked_host_is_refused(self) -> None:
+        result, failure = self._fetch("http://blocked.invalid/payload")
+
+        self.assertFalse(result)
+        self.assertIsInstance(failure[0].value, download.BlockedAddress)
+
+    def test_each_redirect_hop_is_validated(self) -> None:
+        # An agent that follows redirects itself would reach the new location
+        # unchecked, which is how a public URL smuggles you to a private one.
+        self.responses = [
+            FakeResponse(302, "http://blocked.invalid/inner"),
+            FakeResponse(),
+        ]
+
+        result, failure = self._fetch("http://example.invalid/payload")
+
+        self.assertFalse(result)
+        self.assertIsInstance(failure[0].value, download.BlockedAddress)
+        self.assertEqual(self.validated, ["example.invalid", "blocked.invalid"])
+
+    def test_relative_redirect_resolves_against_the_current_url(self) -> None:
+        self.responses = [FakeResponse(302, "/second"), FakeResponse()]
+
+        _result, failure = self._fetch("http://example.invalid/first")
+
+        self.assertFalse(failure)
+        self.assertEqual(
+            [url for url, _ in self.requested],
+            ["http://example.invalid/first", "http://example.invalid/second"],
+        )
+
+    def test_redirect_loop_gives_up(self) -> None:
+        self.responses = [FakeResponse(302, "http://example.invalid/x")] * 10
+
+        result, failure = self._fetch("http://example.invalid/x")
+
+        self.assertFalse(result)
+        self.assertIsInstance(failure[0].value, download.TooManyRedirects)
 
 
 if __name__ == "__main__":

--- a/src/cowrie/test/test_ftpget.py
+++ b/src/cowrie/test/test_ftpget.py
@@ -22,7 +22,13 @@ from twisted.internet import reactor as _reactor
 from twisted.protocols.ftp import FTPFactory, FTPRealm
 
 from cowrie.commands import ftpget as ftpget_module
-from cowrie.commands.ftpget import FTPFileReceiver, ftpget_rate_limiter
+from cowrie.commands.ftpget import (
+    Command_ftpget,
+    FTPFileReceiver,
+    ftpget_rate_limiter,
+)
+from cowrie.core.artifact import Artifact
+from cowrie.shell.command import HoneyPotCommand
 from cowrie.shell.protocol import HoneyPotInteractiveProtocol
 from cowrie.test.eventcapture import capture_events
 from cowrie.test.fake_server import FakeAvatar, FakeServer
@@ -35,8 +41,6 @@ if TYPE_CHECKING:
         IReactorTCP,
         IReactorTime,
     )
-
-    from cowrie.core.artifact import Artifact
 
     class _Reactor(IReactorTime, IReactorTCP):
         pass
@@ -106,7 +110,9 @@ class ShellFtpGetCommandTests(unittest.TestCase):
         """ftpget reports a connection error when nothing listens on the port"""
         port = closed_loopback_port()
         with mock.patch.object(
-            ftpget_module, "communication_allowed", lambda _address: defer.succeed(True)
+            ftpget_module,
+            "resolve_allowed",
+            lambda address: defer.succeed(address),
         ):
             self.proto.lineReceived(
                 f"ftpget -P {port} 127.0.0.1 /tmp/test.txt remote.txt\n".encode()
@@ -115,6 +121,64 @@ class ShellFtpGetCommandTests(unittest.TestCase):
                 pump(lambda: b"ftpget:" in self.tr.value()), "no error output"
             )
         self.assertIn(b"ftpget: Connection failed", self.tr.value())
+
+
+class FtpGetPinnedAddressTests(unittest.TestCase):
+    """The transfer connects to the address that was validated."""
+
+    def setUp(self) -> None:
+        self.proto = HoneyPotInteractiveProtocol(FakeAvatar(FakeServer()))
+        self.tr = FakeTransport("", "31337")
+        self.proto.makeConnection(self.tr)
+        self.tr.clear()
+        capture_events(self.proto)
+        ftpget_rate_limiter.reset()
+
+    def tearDown(self) -> None:
+        self.proto.connectionLost()
+
+    def test_connects_to_the_resolved_address(self) -> None:
+        # Resolving the hostname a second time at connect time lets a
+        # malicious DNS server answer the check and the connection
+        # differently.
+        captured: dict[str, Any] = {}
+
+        class FakeCreator:
+            def __init__(self, *a: Any, **k: Any) -> None:
+                pass
+
+            def connectTCP(self, host: str, port: int, **kwargs: Any) -> Any:
+                captured["host"] = host
+                return defer.Deferred()
+
+        with (
+            mock.patch.object(
+                ftpget_module,
+                "resolve_allowed",
+                lambda _address: defer.succeed("198.51.100.7"),
+            ),
+            mock.patch.object(ftpget_module, "ClientCreator", FakeCreator),
+        ):
+            self.proto.lineReceived(b"ftpget host.invalid /tmp/f.txt remote.txt\n")
+
+        self.assertEqual(captured.get("host"), "198.51.100.7")
+
+
+class FtpGetArtifactCleanupTests(unittest.TestCase):
+    """An interrupted transfer must not leave its temp file behind."""
+
+    def test_ctrl_c_removes_the_empty_artifact(self) -> None:
+        cmd = Command_ftpget.__new__(Command_ftpget)
+        cmd.artifactFile = Artifact("ftpget-test")
+        temp_name = cmd.artifactFile.fp.name
+        self.assertTrue(os.path.exists(temp_name))
+
+        with mock.patch.object(HoneyPotCommand, "exit"):
+            cmd.exit()
+
+        self.assertFalse(
+            os.path.exists(temp_name), "aborted transfer left its temp file behind"
+        )
 
 
 class FTPFileReceiverSizeLimitTests(unittest.TestCase):
@@ -188,7 +252,9 @@ class ShellFtpGetAsyncTests(unittest.TestCase):
         # The limiter is a module-level singleton; keep tests isolated.
         ftpget_rate_limiter.reset()
         allow_loopback = mock.patch.object(
-            ftpget_module, "communication_allowed", lambda _address: defer.succeed(True)
+            ftpget_module,
+            "resolve_allowed",
+            lambda address: defer.succeed(address),
         )
         allow_loopback.start()
         self.addCleanup(allow_loopback.stop)

--- a/src/cowrie/test/test_proxy_transport.py
+++ b/src/cowrie/test/test_proxy_transport.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Tests for the proxy frontend SSH transport's packet and version handling.
+# ABOUTME: Covers fingerprintable responses, message framing and torn-down transports.
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from twisted.conch.ssh import transport
+
+from cowrie.ssh_proxy.server_transport import FrontendSSHTransport
+
+
+def _transport() -> FrontendSSHTransport:
+    """A frontend transport with only the attributes these tests touch."""
+    t = FrontendSSHTransport.__new__(FrontendSSHTransport)
+    t.transport = MagicMock()
+    t._log = MagicMock()
+    t.events = None
+    return t
+
+
+class TestSendDisconnect(unittest.TestCase):
+    """A bad packet length must not draw a fingerprintable reply."""
+
+    def test_bad_packet_length_writes_nothing(self) -> None:
+        # "Packet corrupt" is a documented Cowrie tell: no real SSH server
+        # answers a bad packet length with it.
+        t = _transport()
+
+        t.sendDisconnect(transport.DISCONNECT_PROTOCOL_ERROR, b"bad packet length")
+
+        t.transport.write.assert_not_called()
+        t.transport.loseConnection.assert_called_once()
+
+
+class TestSendPacket(unittest.TestCase):
+    """Packet framing must survive a torn-down transport and high message types."""
+
+    def _ready(self) -> FrontendSSHTransport:
+        t = _transport()
+        t._keyExchangeState = t._KEY_EXCHANGE_NONE
+        t.outgoingCompression = None
+        t.currentEncryptions = MagicMock()
+        t.currentEncryptions.encBlockSize = 8
+        t.currentEncryptions.encrypt = lambda packet: packet
+        t.currentEncryptions.makeMAC = lambda _seq, _packet: b""
+        t.outgoingPacketSequence = 0
+        return t
+
+    def test_no_transport_is_not_an_error(self) -> None:
+        # Twisted keeps dispatching queued messages after the connection is
+        # gone; writing to a None transport raises AttributeError.
+        t = self._ready()
+        t.transport = None
+
+        t.sendPacket(transport.MSG_IGNORE, b"")
+
+    def test_high_message_type_is_one_byte(self) -> None:
+        # chr(200).encode() is two UTF-8 bytes, which shifts the whole
+        # payload and corrupts every message type above 127.
+        t = self._ready()
+
+        t.sendPacket(200, b"body")
+
+        written = t.transport.write.call_args[0][0]
+        # 4-byte length, 1-byte padding length, then the message type.
+        self.assertEqual(written[5], 200)
+        self.assertEqual(written[6:10], b"body")
+
+
+class TestVersionParsing(unittest.TestCase):
+    """A version string without a literal dot is a protocol mismatch."""
+
+    def test_non_dot_separator_is_rejected(self) -> None:
+        # An unescaped dot in the pattern matches any character, so
+        # "SSH-2X0-x" parses as version "2X0" and reaches the
+        # unsupported-version path instead of the mismatch path.
+        t = _transport()
+        t.buf = b"SSH-2X0-libssh\n"
+        t.gotVersion = False
+        t.transport.getPeer.return_value = MagicMock(host="10.0.0.1", port=1234)
+
+        t.dataReceived(b"")
+
+        t.transport.write.assert_called_once_with(b"Protocol mismatch.\n")
+        self.assertFalse(t.gotVersion)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_proxy_transport.py
+++ b/src/cowrie/test/test_proxy_transport.py
@@ -15,13 +15,14 @@ from twisted.conch.ssh import transport
 from cowrie.ssh_proxy.server_transport import FrontendSSHTransport
 
 
-def _transport() -> FrontendSSHTransport:
-    """A frontend transport with only the attributes these tests touch."""
+def _transport() -> tuple[FrontendSSHTransport, MagicMock]:
+    """A frontend transport, and the mock standing in for its connection."""
     t = FrontendSSHTransport.__new__(FrontendSSHTransport)
-    t.transport = MagicMock()
+    connection = MagicMock()
+    t.transport = connection
     t._log = MagicMock()
     t.events = None
-    return t
+    return t, connection
 
 
 class TestSendDisconnect(unittest.TestCase):
@@ -30,19 +31,19 @@ class TestSendDisconnect(unittest.TestCase):
     def test_bad_packet_length_writes_nothing(self) -> None:
         # "Packet corrupt" is a documented Cowrie tell: no real SSH server
         # answers a bad packet length with it.
-        t = _transport()
+        t, connection = _transport()
 
         t.sendDisconnect(transport.DISCONNECT_PROTOCOL_ERROR, b"bad packet length")
 
-        t.transport.write.assert_not_called()
-        t.transport.loseConnection.assert_called_once()
+        connection.write.assert_not_called()
+        connection.loseConnection.assert_called_once()
 
 
 class TestSendPacket(unittest.TestCase):
     """Packet framing must survive a torn-down transport and high message types."""
 
-    def _ready(self) -> FrontendSSHTransport:
-        t = _transport()
+    def _ready(self) -> tuple[FrontendSSHTransport, MagicMock]:
+        t, connection = _transport()
         t._keyExchangeState = t._KEY_EXCHANGE_NONE
         t.outgoingCompression = None
         t.currentEncryptions = MagicMock()
@@ -50,12 +51,12 @@ class TestSendPacket(unittest.TestCase):
         t.currentEncryptions.encrypt = lambda packet: packet
         t.currentEncryptions.makeMAC = lambda _seq, _packet: b""
         t.outgoingPacketSequence = 0
-        return t
+        return t, connection
 
     def test_no_transport_is_not_an_error(self) -> None:
         # Twisted keeps dispatching queued messages after the connection is
         # gone; writing to a None transport raises AttributeError.
-        t = self._ready()
+        t, _connection = self._ready()
         t.transport = None
 
         t.sendPacket(transport.MSG_IGNORE, b"")
@@ -63,11 +64,11 @@ class TestSendPacket(unittest.TestCase):
     def test_high_message_type_is_one_byte(self) -> None:
         # chr(200).encode() is two UTF-8 bytes, which shifts the whole
         # payload and corrupts every message type above 127.
-        t = self._ready()
+        t, connection = self._ready()
 
         t.sendPacket(200, b"body")
 
-        written = t.transport.write.call_args[0][0]
+        written = connection.write.call_args[0][0]
         # 4-byte length, 1-byte padding length, then the message type.
         self.assertEqual(written[5], 200)
         self.assertEqual(written[6:10], b"body")
@@ -80,14 +81,14 @@ class TestVersionParsing(unittest.TestCase):
         # An unescaped dot in the pattern matches any character, so
         # "SSH-2X0-x" parses as version "2X0" and reaches the
         # unsupported-version path instead of the mismatch path.
-        t = _transport()
+        t, connection = _transport()
         t.buf = b"SSH-2X0-libssh\n"
         t.gotVersion = False
-        t.transport.getPeer.return_value = MagicMock(host="10.0.0.1", port=1234)
+        connection.getPeer.return_value = MagicMock(host="10.0.0.1", port=1234)
 
         t.dataReceived(b"")
 
-        t.transport.write.assert_called_once_with(b"Protocol mismatch.\n")
+        connection.write.assert_called_once_with(b"Protocol mismatch.\n")
         self.assertFalse(t.gotVersion)
 
 

--- a/src/cowrie/test/test_wget.py
+++ b/src/cowrie/test/test_wget.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse
 
 from twisted.internet import defer, error
 from twisted.python.failure import Failure
+from twisted.web.client import URI
 from twisted.web.http_headers import Headers
 
 from cowrie.commands.wget import Command_wget
@@ -193,28 +194,37 @@ class WgetOutboundBindTests(unittest.TestCase):
     def tearDown(self) -> None:
         CowrieConfig.remove_option("honeypot", "out_addr")
 
-    def _captured_agent(self) -> Any:
-        """Run httpDownload with treq.get stubbed and return the agent it used.
-        The agent's endpoint factory carries the source address it binds to."""
+    def _captured_bind_address(self) -> Any:
+        """Run httpDownload with the HTTP call stubbed and return the source
+        address the connection it built would bind to."""
         cmd = Command_wget.__new__(Command_wget)
+        cmd.wget_version = "1.21"
         captured: dict[str, Any] = {}
 
         def fake_get(url: str, agent: Any = None, **kwargs: Any) -> Any:
             captured["agent"] = agent
-            return defer.succeed(None)
+            return defer.succeed(mock.Mock(code=200, headers=Headers()))
 
-        with mock.patch("cowrie.commands.wget.treq.get", fake_get):
+        with (
+            mock.patch("cowrie.core.download.treq.get", fake_get),
+            mock.patch(
+                "cowrie.core.download.resolve_allowed",
+                lambda _host: defer.succeed("198.51.100.1"),
+            ),
+        ):
             cmd.httpDownload("http://198.51.100.1/x")
-        return captured["agent"]
+
+        endpoint = captured["agent"]._endpointFactory.endpointForURI(
+            URI.fromBytes(b"http://198.51.100.1/x")
+        )
+        return endpoint._bindAddress
 
     def test_http_download_binds_agent_to_out_addr(self) -> None:
         CowrieConfig.set("honeypot", "out_addr", "127.0.0.1")
-        agent = self._captured_agent()
-        self.assertEqual(agent._endpointFactory._bindAddress, ("127.0.0.1", 0))
+        self.assertEqual(self._captured_bind_address(), ("127.0.0.1", 0))
 
     def test_http_download_default_bind_is_wildcard(self) -> None:
-        agent = self._captured_agent()
-        self.assertEqual(agent._endpointFactory._bindAddress, ("0.0.0.0", 0))
+        self.assertEqual(self._captured_bind_address(), ("0.0.0.0", 0))
 
     def test_ftp_download_binds_to_out_addr(self) -> None:
         CowrieConfig.set("honeypot", "out_addr", "127.0.0.1")


### PR DESCRIPTION
Three related maintainability fixes, each commit standalone.

## Release integrity

- `weekly-release.yml` had no `github.repository` guard (the publish workflows all have one), so the schedule also fired on forks and bootstrapped a parallel `v0.0.x` tag series there. setuptools-scm derives the version from the *nearest* tag, so such a tag interleaved with the real `v3.0.x` line makes a release compute a `0.0.x` version — a PyPI upload that cannot be undone. (Six such tags existed on a fork and have been deleted.)
- Both publish workflows grep for `not initialised` while `cowrie start` prints `not initialized`, so the smoke test has been failing on every release even though the upload itself succeeded. They also `pip install cowrie` unpinned, which silently tests the *previous* release when the index lags; they now install the exact version the run built.
- The publish workflows pinned setuptools 80.9.0 / packaging 25.0 while `[dev]` pins 83.0.0 / 26.2, so release artifacts were built with a toolchain no CI job tests.
- Dropped the unused `logLevel` / `tags` dispatch inputs; `logLevel` was `required: true`, which the weekly job's argument-less dispatch relies on defaulting.

## ssh_proxy transport parity

`ssh/transport.py` and `ssh_proxy/server_transport.py` share ~110 duplicated lines, and fixes landed on the shell side only:

- The anti-fingerprinting fix from #1530 (2021) — the proxy still answered a bad packet length with `Packet corrupt`, which no real SSH server sends.
- The None-transport guard from #40324 — queued messages dispatched after teardown raised `AttributeError`.
- `chr(messageType).encode()` UTF-8 encodes, so every message type above 127 was framed as two bytes and shifted the payload.
- The version regex `SSH-(\d+.\d+)` matched any character where a dot belongs, so `SSH-2X0-x` parsed as version `2X0`.

## Outbound downloads (closes #40390)

`wget`, `curl` and `ftpget` validated the hostname against the blocklist and then handed that *name* to the connect call, which resolved it a second time — a malicious DNS server can answer the validation lookup with a public address and the connection lookup with a private one. wget additionally let the agent follow redirects, so only the first URL was ever checked.

New `cowrie/core/download.py` holds the shared machinery: rate-limiter construction, an agent that connects to an already-validated address (TLS verification and SNI still use the hostname), a `fetch()` that validates and pins **every** redirect hop, and the honeyfs/event bookkeeping for a captured file. wget, curl and ftpget now connect to what they validated; all five fetching commands build their limiter the same way.

Also fixes ftpget leaving its empty temp file behind when a transfer is interrupted — it had neither the `handle_CTRL_C` nor the `exit()` override its siblings grew.

### Deliberately not included

- `tftp` keeps its own resolve-then-validate code: it is already correct, and `resolve_allowed()` cannot distinguish "unresolvable" from "blocked", which tftp reports differently.
- `nc` still captures no artifacts and emits no `file_download` event, so payloads delivered over nc are lost. That is a behaviour change rather than a de-duplication, so it is left for a separate discussion.

Full suite green (1015 tests), `ruff check` clean.
