### PR TITLE
fix: sqlite output drops file uploads and session input

### DIFF
--- a/src/cowrie/output/sqlite.py
+++ b/src/cowrie/output/sqlite.py
@@ -144,6 +144,31 @@ class Output(cowrie.core.output.Output):
                 (event["session"], event["timestamp"], event["url"], None, None),
             )
 
+        elif event["eventid"] == "cowrie.session.file_upload":
+            self.simpleQuery(
+                "INSERT INTO `downloads` (`session`, `timestamp`, `url`, `outfile`, `shasum`) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    event["session"],
+                    event["timestamp"],
+                    "",
+                    event["outfile"],
+                    event["shasum"],
+                ),
+            )
+
+        elif event["eventid"] == "cowrie.session.input":
+            self.simpleQuery(
+                "INSERT INTO `input` (`session`, `timestamp`, `realm`, `input`) "
+                "VALUES (?, ?, ?, ?)",
+                (
+                    event["session"],
+                    event["timestamp"],
+                    event["realm"],
+                    event["input"],
+                ),
+            )
+
         elif event["eventid"] == "cowrie.client.version":
             r = yield self.db.runQuery(
                 "SELECT `id` FROM `clients` WHERE `version` = ?", (event["version"],)

--- a/src/cowrie/test/test_output_sql_parity.py
+++ b/src/cowrie/test/test_output_sql_parity.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: The mysql, postgresql and sqlite output plugins are ports of one
+# ABOUTME: another; this pins the events all three must store to a database.
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import types
+import unittest
+from typing import Any
+from unittest.mock import Mock, patch
+
+from twisted.internet import defer
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+
+def _stub_drivers() -> None:
+    """The database drivers are optional dependencies; stub the missing ones
+    so the plugins import and their SQL can be inspected."""
+    try:
+        import mysql.connector  # noqa: F401
+    except ImportError:
+        _mysql = types.ModuleType("mysql")
+        _connector = types.ModuleType("mysql.connector")
+        _connector.Error = type("Error", (Exception,), {})  # type: ignore[attr-defined]
+        _connector.errorcode = types.SimpleNamespace(  # type: ignore[attr-defined]
+            CR_CONN_HOST_ERROR=2003,
+            CR_SERVER_GONE_ERROR=2006,
+            CR_SERVER_LOST=2013,
+            ER_LOCK_DEADLOCK=1213,
+        )
+        _mysql.connector = _connector  # type: ignore[attr-defined]
+        sys.modules["mysql"] = _mysql
+        sys.modules["mysql.connector"] = _connector
+
+    try:
+        import psycopg2  # noqa: F401
+    except ImportError:
+        _psycopg2 = types.ModuleType("psycopg2")
+        _psycopg2.Error = type("Error", (Exception,), {})  # type: ignore[attr-defined]
+        _psycopg2.OperationalError = type(  # type: ignore[attr-defined]
+            "OperationalError", (Exception,), {}
+        )
+        _extras = types.ModuleType("psycopg2.extras")
+        _psycopg2.extras = _extras  # type: ignore[attr-defined]
+        sys.modules["psycopg2"] = _psycopg2
+        sys.modules["psycopg2.extras"] = _extras
+
+
+_stub_drivers()
+
+from cowrie.output import mysql as mysql_output  # noqa: E402
+from cowrie.output import postgresql as postgresql_output  # noqa: E402
+from cowrie.output import sqlite as sqlite_output  # noqa: E402
+
+PLUGINS = {
+    "mysql": mysql_output,
+    "postgresql": postgresql_output,
+    "sqlite": sqlite_output,
+}
+
+# One event per branch, carrying every field any of the three plugins reads.
+# 'time' is what mysql and postgresql pass to their timestamp conversion;
+# 'timestamp' is what sqlite stores directly.
+COMMON = {
+    "session": "s1",
+    "time": 1767225600.0,
+    "timestamp": "2026-01-01T00:00:00.000000Z",
+    "sensor": "unittest",
+}
+
+EVENTS: dict[str, dict[str, Any]] = {
+    "cowrie.session.connect": {
+        **COMMON,
+        "src_ip": "192.0.2.1",
+        "src_port": 4444,
+        "dst_ip": "198.51.100.1",
+        "dst_port": 2222,
+        "protocol": "ssh",
+    },
+    "cowrie.login.success": {**COMMON, "username": "root", "password": "toor"},
+    "cowrie.login.failed": {**COMMON, "username": "root", "password": "hunter2"},
+    "cowrie.session.params": {**COMMON, "arch": "linux-x64-lsb"},
+    "cowrie.command.input": {**COMMON, "input": "uname -a"},
+    "cowrie.command.failed": {**COMMON, "input": "nosuchcmd"},
+    "cowrie.session.file_download": {
+        **COMMON,
+        "url": "http://example.invalid/x",
+        "outfile": "/tmp/x",
+        "shasum": "a" * 64,
+    },
+    "cowrie.session.file_download.failed": {
+        **COMMON,
+        "url": "http://example.invalid/x",
+    },
+    "cowrie.session.file_upload": {
+        **COMMON,
+        "outfile": "/tmp/x",
+        "shasum": "b" * 64,
+        "filename": "payload.bin",
+    },
+    "cowrie.session.input": {**COMMON, "realm": "shell", "input": "id"},
+    "cowrie.client.version": {**COMMON, "version": "SSH-2.0-OpenSSH_9.6"},
+    "cowrie.client.size": {**COMMON, "width": 80, "height": 24},
+    "cowrie.session.closed": {**COMMON, "duration": 12.5},
+    "cowrie.log.closed": {**COMMON, "ttylog": "log/tty/x.log", "size": 42},
+    "cowrie.client.fingerprint": {**COMMON, "username": "root", "fingerprint": "aa:bb"},
+}
+
+
+def _plugin(module: Any) -> Any:
+    """Construct a plugin without running its config-reading start()."""
+    with patch.object(module.Output, "start", lambda self: None):
+        out = module.Output()
+    out.db = Mock()
+    # Enough shape for the "look up the id, else insert" branches.
+    out.db.runQuery.return_value = defer.succeed([(1,)])
+    out.db.runOperation.return_value = defer.succeed(None)
+    out.db.runInteraction.return_value = defer.succeed(1)
+    return out
+
+
+def _statements(out: Any) -> list[str]:
+    calls = out.db.runQuery.call_args_list + out.db.runOperation.call_args_list
+    return [call[0][0] for call in calls if call[0]]
+
+
+class SqlOutputParityTests(unittest.TestCase):
+    """Every event one plugin stores, all three must store."""
+
+    def test_every_plugin_stores_every_event(self) -> None:
+        missing: list[str] = []
+
+        for eventid, payload in EVENTS.items():
+            for name, module in PLUGINS.items():
+                out = _plugin(module)
+                out.write({"eventid": eventid, **payload})
+                if not _statements(out):
+                    missing.append(f"{name} drops {eventid}")
+
+        self.assertEqual(missing, [], "\n".join(missing))
+
+    def test_plugins_write_to_the_same_tables(self) -> None:
+        """A port that reaches a different table records different history."""
+        divergent: list[str] = []
+
+        for eventid, payload in EVENTS.items():
+            tables: dict[str, set[str]] = {}
+            for name, module in PLUGINS.items():
+                out = _plugin(module)
+                out.write({"eventid": eventid, **payload})
+                tables[name] = {
+                    word.strip("`\"';")
+                    for statement in _statements(out)
+                    for keyword, word in zip(
+                        statement.split(), statement.split()[1:], strict=False
+                    )
+                    if keyword.upper() in ("INTO", "FROM", "UPDATE")
+                }
+
+            if len(set(map(frozenset, tables.values()))) > 1:
+                divergent.append(f"{eventid}: {tables}")
+
+        self.assertEqual(divergent, [], "\n".join(divergent))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cowrie/test/test_output_sqlite.py
+++ b/src/cowrie/test/test_output_sqlite.py
@@ -77,7 +77,9 @@ class OutputSqliteEventCoverageTests(unittest.TestCase):
         out.db.runQuery.return_value = defer.succeed(None)
         out.db.runOperation.return_value = defer.succeed(None)
         out.write(event)
-        return out.db.runQuery.call_args_list + out.db.runOperation.call_args_list
+        calls: list[Any] = list(out.db.runQuery.call_args_list)
+        calls += list(out.db.runOperation.call_args_list)
+        return calls
 
     def test_file_upload_is_stored(self) -> None:
         # An SFTP upload is a captured payload; dropping it loses the record

--- a/src/cowrie/test/test_output_sqlite.py
+++ b/src/cowrie/test/test_output_sqlite.py
@@ -68,5 +68,56 @@ class OutputSqliteHardeningTests(unittest.TestCase):
         self.assertEqual(args[-2:], (None, None))
 
 
+class OutputSqliteEventCoverageTests(unittest.TestCase):
+    """Events the other SQL plugins store must not be dropped here."""
+
+    def _executed(self, event: dict[str, Any]) -> list[Any]:
+        out = _make()
+        out.db = Mock()
+        out.db.runQuery.return_value = defer.succeed(None)
+        out.db.runOperation.return_value = defer.succeed(None)
+        out.write(event)
+        return out.db.runQuery.call_args_list + out.db.runOperation.call_args_list
+
+    def test_file_upload_is_stored(self) -> None:
+        # An SFTP upload is a captured payload; dropping it loses the record
+        # that the file ever arrived.
+        calls = self._executed(
+            {
+                "eventid": "cowrie.session.file_upload",
+                "session": "s1",
+                "timestamp": "2026-01-01T00:00:00.000000Z",
+                "shasum": "a" * 64,
+                "outfile": "/tmp/x",
+                "filename": "payload.bin",
+            }
+        )
+
+        self.assertTrue(calls, "file_upload was not written to the database")
+        self.assertTrue(
+            any("downloads" in call[0][0] for call in calls),
+            f"no insert into downloads: {[c[0][0] for c in calls]}",
+        )
+
+    def test_session_input_is_stored(self) -> None:
+        # Direct-tcpip and telnet sessions report commands through
+        # cowrie.session.input rather than cowrie.command.input.
+        calls = self._executed(
+            {
+                "eventid": "cowrie.session.input",
+                "session": "s1",
+                "timestamp": "2026-01-01T00:00:00.000000Z",
+                "realm": "shell",
+                "input": "uname -a",
+            }
+        )
+
+        self.assertTrue(calls, "session.input was not written to the database")
+        self.assertTrue(
+            any("input" in call[0][0] for call in calls),
+            f"no insert into input: {[c[0][0] for c in calls]}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The `mysql`, `postgresql` and `sqlite` output plugins are line-for-line ports of one another with nothing keeping them in step. This fixes the divergence that has already cost data, and adds the test that prevents the next one.

## sqlite was silently dropping two event types

`sqlite.py` was ported from `mysql.py` without the `cowrie.session.file_upload` and `cowrie.session.input` branches. Operators running the sqlite backend have no record of SFTP uploads, nor of the commands that direct-tcpip and telnet sessions report through `session.input`. Both target tables (`downloads`, `input`) already exist in `docs/sql/sqlite3.sql`, so this is purely a missing dispatch branch — no schema change.

## A parity test so it cannot happen again

`test_output_sql_parity.py` feeds one event per branch through all three plugins and fails when any of them stores nothing, or reaches a different table than its siblings. It stubs the optional mysql/psycopg2 drivers using the pattern already in `test_output_mysql.py`, so it runs everywhere.

Verified it fails on the unfixed code, naming both dropped events:

```
AssertionError: ['sqlite drops cowrie.session.file_upload',
                 'sqlite drops cowrie.session.input'] != []
```

## Not included: the base-class collapse

The obvious follow-up is collapsing the three plugins onto one base class with per-dialect hooks — roughly 800 lines of triplicated SQL. I stopped short of it deliberately. The dialects differ in placeholder style (`%s` vs `?`), timestamp conversion (`FROM_UNIXTIME` vs `TO_TIMESTAMP` vs a stored ISO string, reading different event fields), identifier quoting, and how each retrieves a last-insert id. Routing every statement through a translation layer risks emitting SQL that is subtly invalid for a dialect, and neither the MySQL nor the PostgreSQL driver can be exercised in this test environment — the tests would only prove the generator emits the strings I expected, not that any database accepts them.

That refactor wants either real database integration tests or an agreed dialect-hook design first. The parity test here is the safety net it would need either way.

Full suite green (1002 tests), `ruff check` clean.
