### PR TITLE
fix: accept an HTTP-date Retry-After in abuseipdb

### DIFF
--- a/src/cowrie/output/abuseipdb.py
+++ b/src/cowrie/output/abuseipdb.py
@@ -19,12 +19,14 @@ __version__ = "0.3b3"
 import pickle
 from collections import deque
 from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from json.decoder import JSONDecodeError
 from pathlib import Path
 from time import sleep, time
 
 from treq import post
 from twisted.internet import defer, reactor, threads
+from twisted.logger import Logger
 from twisted.web import http
 
 from cowrie.core import output
@@ -323,6 +325,8 @@ class Reporter:
     HTTP client and methods for preparing report paramaters.
     """
 
+    _log = Logger()
+
     def __init__(self, logbook, attempts, dispatch):
         self.logbook = logbook
         self.attempts = attempts
@@ -439,8 +443,13 @@ class Reporter:
         retry_after = yield response.headers.hasHeader("Retry-After")
 
         if retry_after:
-            retry = yield response.headers.getRawHeaders("Retry-After")
-            retry = int(retry.pop())
+            raw = yield response.headers.getRawHeaders("Retry-After")
+            retry = self.parse_retry_after(raw.pop())
+
+            if retry is None:
+                # Nothing usable to back off by, the same position a 429
+                # without the header at all leaves us in.
+                return
 
             if retry > 86340:
                 yield threads.deferToThread(self.sleeper_thread)
@@ -474,6 +483,31 @@ class Reporter:
                 retry_after=retry,
                 wake_at=self.epoch_to_string_utc(self.logbook.sleep_until),
             )
+
+    def parse_retry_after(self, value):
+        """Seconds to wait, from a Retry-After header value.
+
+        RFC 9110 allows either delta-seconds or an HTTP-date. Returns None for
+        a value that is neither, and 0 for a date already in the past.
+        """
+        try:
+            return int(value)
+        except ValueError:
+            pass
+
+        try:
+            when = parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            self._log.info(
+                "AbuseIPDB plugin could not parse Retry-After header {value!r}",
+                value=value,
+            )
+            return None
+
+        # An HTTP-date without a zone is GMT by the grammar that produced it.
+        if when.tzinfo is None:
+            when = when.replace(tzinfo=timezone.utc)
+        return max(0, int(when.timestamp() - time()))
 
     def sleeper_thread(self):
         # Cheap retry wait hack. Call in thread so as not to block.

--- a/src/cowrie/test/test_abuseipdb.py
+++ b/src/cowrie/test/test_abuseipdb.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 Michel Oosterhof <michel@oosterhof.net>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# ABOUTME: Retry-After tells the abuseipdb plugin how long to stop reporting
+# ABOUTME: for; HTTP allows it in seconds or as a date, so both must parse.
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+from unittest.mock import Mock
+
+os.environ["COWRIE_HONEYPOT_DATA_PATH"] = "data"
+os.environ["COWRIE_HONEYPOT_DOWNLOAD_PATH"] = tempfile.gettempdir()
+os.environ["COWRIE_SHELL_FILESYSTEM"] = "src/cowrie/data/fs.pickle"
+
+from cowrie.output.abuseipdb import Reporter
+
+
+class RetryAfterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.reporter = Reporter.__new__(Reporter)
+        self.reporter.dispatch = Mock()
+
+    def test_delta_seconds(self) -> None:
+        self.assertEqual(self.reporter.parse_retry_after("120"), 120)
+
+    def test_http_date(self) -> None:
+        """RFC 9110 allows an HTTP-date instead of a count of seconds."""
+        when = datetime.now(timezone.utc) + timedelta(minutes=30)
+
+        retry = self.reporter.parse_retry_after(format_datetime(when, usegmt=True))
+
+        self.assertIsNotNone(retry)
+        assert retry is not None
+        self.assertAlmostEqual(retry, 1800, delta=5)
+
+    def test_http_date_in_the_past(self) -> None:
+        """Never a negative wait, which callLater would fire immediately on."""
+        when = datetime.now(timezone.utc) - timedelta(minutes=30)
+
+        self.assertEqual(
+            self.reporter.parse_retry_after(format_datetime(when, usegmt=True)), 0
+        )
+
+    def test_unparseable_value(self) -> None:
+        self.assertIsNone(self.reporter.parse_retry_after("soon please"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`Reporter.rate_limit_handler()` parsed the `Retry-After` response header with `retry = int(retry.pop())`. RFC 9110 §10.2.3 allows that header as either delta-seconds **or** an HTTP-date, and there was no fallback for the date form.

The practical effect is worse than a crash. The `ValueError` is raised inside an `@defer.inlineCallbacks` generator whose Deferred nobody consumes, so it surfaces only as an unhandled error in a Deferred — while everything below the failing line never runs. That's the code that sets `logbook.sleeping` and schedules the wake-up, so the plugin would go on reporting IPs to AbuseIPDB straight past the point it was told to back off.

Added `parse_retry_after()`, which accepts both forms and returns `None` for a value that is neither. `None` skips the sleep — the same position a 429 with no `Retry-After` header at all already leaves the plugin in — and logs the unparseable value so an operator can see it. A date already in the past clamps to 0 rather than a negative delay, which `reactor.callLater` would fire on immediately.

`Reporter` had no logger, so it gets the usual `_log = Logger()`.

As the reporter notes, AbuseIPDB isn't documented as sending the date form; this is about the code not ruling it out.

Tests cover delta-seconds, an HTTP-date, a past date, and an unparseable value.

Fixes #40491
